### PR TITLE
Issue #44 done

### DIFF
--- a/cnl-toolchain/src/main/java/cnltoolchain/CNLToolchain.java
+++ b/cnl-toolchain/src/main/java/cnltoolchain/CNLToolchain.java
@@ -2,11 +2,15 @@ package cnltoolchain;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.util.List;
-import java.util.Date;
-import java.util.Calendar;
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;   
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import api.ExecuteMappingAPI;
 import api.ExecuteMappingAPIFactory;
@@ -15,7 +19,6 @@ import api.StardogDatabaseAPI;
 import api.StardogICVAPI;
 import api.exceptions.MissingBuilderArgumentException;
 import api.exceptions.NoConnectionToStardogServerException;
-
 import asciidocparser.AsciiDocArc42Parser;
 import conformancecheck.api.IConformanceCheck;
 import conformancecheck.impl.ConformanceCheckImpl;
@@ -26,9 +29,6 @@ import impl.StardogAPIFactory;
 import impl.StardogDatabase;
 //import impl.StardogDatabase.StardogDatabaseBuilder;
 import parser.FamixOntologyTransformer;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
  
 public class CNLToolchain
 {
@@ -139,11 +139,25 @@ public class CNLToolchain
         if (! directory.exists()){
             directory.mkdir();
         }
-    	
+
+        IConformanceCheck check = new ConformanceCheckImpl();
+        
         String mappingFilePath = TEMPORARY_DIRECTORY + "/mapping.txt";
+        HashMap<String, String> supportedOWLNamespaces = new HashMap<>();
+        
+        supportedOWLNamespaces.putAll(famixTransformer.getProvidedNamespaces());
+        supportedOWLNamespaces.putAll(check.getProvidedNamespaces());
+        
+//        supportedOWLNamespaces.put("java", "http://arch-ont.org/ontologies/javacodeontology.owl#");
+//        supportedOWLNamespaces.put("famix", "http://arch-ont.org/ontologies/famix.owl#");
+//        supportedOWLNamespaces.put("maven", "http://arch-ont.org/ontologies/maven.owl#");
+//        supportedOWLNamespaces.put("main", "http://arch-ont.org/ontologies/main.owl#");
+//        supportedOWLNamespaces.put("osgi", "http://arch-ont.org/ontologies/osgi.owl#");
+//        supportedOWLNamespaces.put("git", "http://www.arch-ont.org/ontologies/git.owl#");
+//        supportedOWLNamespaces.put("architecture", "http://www.arch-ont.org/ontologies/architecture.owl#");
         
     	LOG.info("Start parsing...");
-        AsciiDocArc42Parser parser = new AsciiDocArc42Parser();
+        AsciiDocArc42Parser parser = new AsciiDocArc42Parser(supportedOWLNamespaces);
         parser.parseRulesFromDocumentation(docPath, TEMPORARY_DIRECTORY);
         parser.parseMappingRulesFromDocumentation(docPath, mappingFilePath);
         ontologyPaths = parser.getOntologyPaths();
@@ -175,7 +189,6 @@ public class CNLToolchain
                 context); //TODO ConformanceCheck component?
 
     	LOG.info("Start conformance checking...");
-        IConformanceCheck check = new ConformanceCheckImpl();
         check.createNewConformanceCheck();
         for (ArchitectureRule rule : ArchitectureRules.getInstance()
             .getRules()

--- a/conformance-checking/src/main/java/conformancecheck/api/IConformanceCheck.java
+++ b/conformance-checking/src/main/java/conformancecheck/api/IConformanceCheck.java
@@ -1,5 +1,7 @@
 package conformancecheck.api;
 
+import java.util.Map;
+
 import datatypes.ArchitectureRule;
 import datatypes.ConstraintViolationsResultSet;
 
@@ -23,4 +25,11 @@ public interface IConformanceCheck {
 	 * @param outputPath The path to the file to which the results will be written.
 	 */
 	public void validateRule(ArchitectureRule rule, String modelPath, ConstraintViolationsResultSet violations, String outputPath);
+	
+	/**
+	 * @return 
+	 * 	Returns a map which contains all OWL namespaces which are provided by the component.
+	 * 	The keys are the abbreviations, and the values are the full URIs of these namespaces.
+	 */
+	public Map<String, String> getProvidedNamespaces();
 }

--- a/conformance-checking/src/main/java/conformancecheck/impl/ConformanceCheckImpl.java
+++ b/conformance-checking/src/main/java/conformancecheck/impl/ConformanceCheckImpl.java
@@ -3,12 +3,16 @@ package conformancecheck.impl;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.inject.Inject;
 
@@ -16,9 +20,6 @@ import conformancecheck.api.IConformanceCheck;
 import datatypes.ArchitectureRule;
 import datatypes.ConstraintViolation;
 import datatypes.ConstraintViolationsResultSet;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
  
 
 public class ConformanceCheckImpl implements IConformanceCheck 
@@ -84,5 +85,12 @@ public class ConformanceCheckImpl implements IConformanceCheck
 			LOG.error(e.getMessage());
 			e.printStackTrace();
 		} 
+	}
+
+	@Override
+	public Map<String, String> getProvidedNamespaces() {
+		HashMap<String, String> res = new HashMap<>();
+		res.put("architecture", ConformanceCheckOntologyClassesAndProperties.getOntologyNamespace());
+		return res;
 	}
 }

--- a/conformance-checking/src/main/java/conformancecheck/impl/ConformanceCheckOntologyClassesAndProperties.java
+++ b/conformance-checking/src/main/java/conformancecheck/impl/ConformanceCheckOntologyClassesAndProperties.java
@@ -9,11 +9,15 @@ import org.apache.jena.ontology.OntModel;
 public class ConformanceCheckOntologyClassesAndProperties 
 {
 
-	//TODO: remove hard-coded string
+	//TODO: replace with an URI that is similar to the other ones
 	private static final String namespace = "http://www.semanticweb.org/sandr/ontologies/2018/4/architectureconformance#";
 	private static int violationId;
 	private static int proofId;
 
+	public static String getOntologyNamespace() {
+		return namespace;
+	}
+	
 	public static Individual getConformanceCheckIndividual(OntModel model) 
 	{
 		OntClass conformanceClass = model.getOntClass(namespace + "ConformanceCheck");

--- a/owlify-famix/src/main/java/ontology/FamixOntClassesAndProperties.java
+++ b/owlify-famix/src/main/java/ontology/FamixOntClassesAndProperties.java
@@ -9,6 +9,10 @@ import org.apache.jena.ontology.OntModel;
 public class FamixOntClassesAndProperties {
 	private final String famixOntologyNamespace = "http://arch-ont.org/ontologies/famix.owl#";
 	
+	public String getOntologyNamespace() {
+		return famixOntologyNamespace;
+	}
+	
 	public Individual createNamespaceIndividual(OntModel model, long namespaceId) {
 		OntClass namespaceClass = model.getOntClass(famixOntologyNamespace + "Namespace");
 		return model.createIndividual(this.famixOntologyNamespace + "Namespace" + namespaceId, namespaceClass);

--- a/owlify-famix/src/main/java/ontology/FamixOntology.java
+++ b/owlify-famix/src/main/java/ontology/FamixOntology.java
@@ -51,6 +51,10 @@ public class FamixOntology {
 		loadFamixModel(famixOntologyInputStream);
 	}
 
+	public String getOntologyNamespace() {
+		return classesAndProperties.getOntologyNamespace();
+	}
+	
 	private void loadFamixModel(InputStream famixOntologyInputStream) {
 		model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, null);
 		model.read(famixOntologyInputStream, null);

--- a/owlify-famix/src/main/java/parser/FamixOntologyTransformer.java
+++ b/owlify-famix/src/main/java/parser/FamixOntologyTransformer.java
@@ -142,4 +142,11 @@ public class FamixOntologyTransformer extends AbstractOwlifyComponent {
 		}
 	}
 
+	@Override
+	public Map<String, String> getProvidedNamespaces() {
+		HashMap<String, String> res = new HashMap<>();
+		res.put("famix", ontology.getOntologyNamespace());
+		return res;
+	}
+
 }

--- a/owlify-git/src/main/java/ontology/GitOntClassesAndProperties.java
+++ b/owlify-git/src/main/java/ontology/GitOntClassesAndProperties.java
@@ -17,22 +17,30 @@ import org.apache.jena.rdf.model.Resource;
 public class GitOntClassesAndProperties {
 
 	private OntModel ontoModel;
-	private String gitOntologyNamespace;
-	private String ontologyMainNamespace;
-	private String ontologyHistoryNamespace;
+	private final String ONTOLOGY_GIT_NAMESPACE;
+	private final String ONTOLOGY_MAIN_NAMESPACE;
+	private final String ONTOLOGY_HISTORY_NAMESPACE;
 
 	public GitOntClassesAndProperties() {
-		gitOntologyNamespace = "http://www.arch-ont.org/ontologies/git.owl#";
-		ontologyMainNamespace = "http://arch-ont.org/ontologies/main.owl#";
-		ontologyHistoryNamespace = "http://arch-ont.org/ontologies/history.owl#";
+		ONTOLOGY_GIT_NAMESPACE = "http://www.arch-ont.org/ontologies/git.owl#";
+		ONTOLOGY_MAIN_NAMESPACE = "http://arch-ont.org/ontologies/main.owl#";
+		ONTOLOGY_HISTORY_NAMESPACE = "http://arch-ont.org/ontologies/history.owl#";
 		ontoModel = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, null);
 		ontoModel.read("./ontology/main.owl");
 		ontoModel.read("./ontology/history.owl");
 		ontoModel.read("./ontology/git.owl");
 	}
-
+	
 	public String getOntologyNamespace() {
-		return gitOntologyNamespace;
+		return ONTOLOGY_GIT_NAMESPACE;
+	}
+	
+	public String getMainNamespace() {
+		return ONTOLOGY_MAIN_NAMESPACE;
+	}
+	
+	public String getHistoryNamespace() {
+		return ONTOLOGY_HISTORY_NAMESPACE;
 	}
 
 	public Individual createIndividual(String uri, Resource resource) {
@@ -44,147 +52,147 @@ public class GitOntClassesAndProperties {
 	}
 
 	public OntClass gitRepositoryClass() {
-		return this.ontoModel.getOntClass(gitOntologyNamespace + "GitRepository");
+		return this.ontoModel.getOntClass(ONTOLOGY_GIT_NAMESPACE + "GitRepository");
 	}
 
 	public OntClass gitCommitClass() {
-		return this.ontoModel.getOntClass(gitOntologyNamespace + "GitCommit");
+		return this.ontoModel.getOntClass(ONTOLOGY_GIT_NAMESPACE + "GitCommit");
 	}
 
 	public OntClass gitBranchClass() {
-		return this.ontoModel.getOntClass(gitOntologyNamespace + "GitBranch");
+		return this.ontoModel.getOntClass(ONTOLOGY_GIT_NAMESPACE + "GitBranch");
 	}
 
 	public OntClass gitTagClass() {
-		return this.ontoModel.getOntClass(gitOntologyNamespace + "GitTag");
+		return this.ontoModel.getOntClass(ONTOLOGY_GIT_NAMESPACE + "GitTag");
 	}
 
 	public OntClass gitChangeClass() {
-		return this.ontoModel.getOntClass(gitOntologyNamespace + "GitChange");
+		return this.ontoModel.getOntClass(ONTOLOGY_GIT_NAMESPACE + "GitChange");
 	}
 
 	public OntClass gitAuthor() {
-		return this.ontoModel.getOntClass(gitOntologyNamespace + "GitAuthor");
+		return this.ontoModel.getOntClass(ONTOLOGY_GIT_NAMESPACE + "GitAuthor");
 	}
 
 	public OntClass gitCommitter() {
-		return this.ontoModel.getOntClass(ontologyHistoryNamespace + "Committer");
+		return this.ontoModel.getOntClass(ONTOLOGY_HISTORY_NAMESPACE + "Committer");
 	}
 	
 	public Resource fileClass() {
-		return this.ontoModel.getOntClass(ontologyMainNamespace + "SoftwareArtifactFile");
+		return this.ontoModel.getOntClass(ONTOLOGY_MAIN_NAMESPACE + "SoftwareArtifactFile");
 	}
 
 	// Data Properties
 	public DatatypeProperty hasNameProperty() {
-		return ontoModel.getDatatypeProperty(ontologyMainNamespace + "hasName");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_MAIN_NAMESPACE + "hasName");
 	}
 
 	public DatatypeProperty hasSHAProperty() {
-		return ontoModel.getDatatypeProperty(gitOntologyNamespace + "hasSHAIdentifier");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_GIT_NAMESPACE + "hasSHAIdentifier");
 	}
 
 	public DatatypeProperty hasMessageProperty() {
-		return ontoModel.getDatatypeProperty(gitOntologyNamespace + "hasMessage");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_GIT_NAMESPACE + "hasMessage");
 	}
 
 	public DatatypeProperty hasShortMessageProperty() {
 		// TODO Auto-generated method stub
-		return ontoModel.getDatatypeProperty(gitOntologyNamespace + "hasShortMessage");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_GIT_NAMESPACE + "hasShortMessage");
 	}
 	
 	public DatatypeProperty hasCommitDateProperty() {
-		return ontoModel.getDatatypeProperty(ontologyHistoryNamespace + "committedOn");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_HISTORY_NAMESPACE + "committedOn");
 	}
 	
 	public DatatypeProperty hasRelativePathProperty() {
-		return ontoModel.getDatatypeProperty(ontologyMainNamespace + "hasRelativePath");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_MAIN_NAMESPACE + "hasRelativePath");
 	}
 	
 	public DatatypeProperty isCreatedOnProperty() {
-		return ontoModel.getDatatypeProperty(ontologyHistoryNamespace + "isCreatedOn");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_HISTORY_NAMESPACE + "isCreatedOn");
 	}
 	
 	public DatatypeProperty copiedOnProperty() {
-		return ontoModel.getDatatypeProperty(ontologyHistoryNamespace + "isCopiedOn");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_HISTORY_NAMESPACE + "isCopiedOn");
 	}
 	
 	public DatatypeProperty isDeletedOnProperty() {
-		return ontoModel.getDatatypeProperty(ontologyHistoryNamespace + "isDeletedOn");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_HISTORY_NAMESPACE + "isDeletedOn");
 	}
 	
 	public DatatypeProperty renamedOnProperty() {
-		return ontoModel.getDatatypeProperty(ontologyHistoryNamespace + "isRenamedOn");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_HISTORY_NAMESPACE + "isRenamedOn");
 	}
 	
 	public DatatypeProperty lastModificationOnProperty() {
-		return ontoModel.getDatatypeProperty(ontologyHistoryNamespace + "lastModifiedOn");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_HISTORY_NAMESPACE + "lastModifiedOn");
 	}
 	
 	public DatatypeProperty hasLabelProperty() {
-		return ontoModel.getDatatypeProperty(gitOntologyNamespace + "hasLabel");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_GIT_NAMESPACE + "hasLabel");
 	}
 	
 	public DatatypeProperty hasEmailAdressProperty() {
-		return ontoModel.getDatatypeProperty(gitOntologyNamespace + "hasEmailAddress");
+		return ontoModel.getDatatypeProperty(ONTOLOGY_GIT_NAMESPACE + "hasEmailAddress");
 	}
 
 	// Object Properties
 	public ObjectProperty hasHeadProperty() {
-		return ontoModel.getObjectProperty(gitOntologyNamespace + "hasHead");
+		return ontoModel.getObjectProperty(ONTOLOGY_GIT_NAMESPACE + "hasHead");
 	}
 
 	public ObjectProperty hasBranchProperty() {
-		return ontoModel.getObjectProperty(gitOntologyNamespace + "hasBranch");
+		return ontoModel.getObjectProperty(ONTOLOGY_GIT_NAMESPACE + "hasBranch");
 	}
 
 	public ObjectProperty hasCommitProperty() {
-		return ontoModel.getObjectProperty(gitOntologyNamespace + "hasCommit");
+		return ontoModel.getObjectProperty(ONTOLOGY_GIT_NAMESPACE + "hasCommit");
 	}
 
 	public ObjectProperty hasAuthorProperty() {
 
-		return ontoModel.getObjectProperty(gitOntologyNamespace + "hasAuthor");
+		return ontoModel.getObjectProperty(ONTOLOGY_GIT_NAMESPACE + "hasAuthor");
 	}
 	
 	public ObjectProperty performsCommitProperty() {
-		return ontoModel.getObjectProperty(ontologyHistoryNamespace + "performsCommit");
+		return ontoModel.getObjectProperty(ONTOLOGY_HISTORY_NAMESPACE + "performsCommit");
 	}
 
 
 	public ObjectProperty hasCommitterProperty() {
-		return ontoModel.getObjectProperty(ontologyHistoryNamespace + "isCommittedBy");
+		return ontoModel.getObjectProperty(ONTOLOGY_HISTORY_NAMESPACE + "isCommittedBy");
 	}
 	
 	public ObjectProperty modifiesFileProperty() {
-		return ontoModel.getObjectProperty(gitOntologyNamespace + "modifiesFile");
+		return ontoModel.getObjectProperty(ONTOLOGY_GIT_NAMESPACE + "modifiesFile");
 	}
 	
 	public ObjectProperty hasModificationKindProperty() {
-		return ontoModel.getObjectProperty(gitOntologyNamespace + "hasModificationKind");
+		return ontoModel.getObjectProperty(ONTOLOGY_GIT_NAMESPACE + "hasModificationKind");
 	}
 	
 	public ObjectProperty createsFileProperty() {
-		return ontoModel.getObjectProperty(ontologyHistoryNamespace + "createsFile");
+		return ontoModel.getObjectProperty(ONTOLOGY_HISTORY_NAMESPACE + "createsFile");
 	}
 	
 	//Individuals
 	
 	public Individual getModificationKindIndividual(String modificationKind) {
 		if(modificationKind.equals("A")) {
-			return ontoModel.getIndividual(gitOntologyNamespace + "Add");
+			return ontoModel.getIndividual(ONTOLOGY_GIT_NAMESPACE + "Add");
 		}
 		else if(modificationKind.equals("D")) {
-			return ontoModel.getIndividual(gitOntologyNamespace + "Delete");
+			return ontoModel.getIndividual(ONTOLOGY_GIT_NAMESPACE + "Delete");
 		}
 		else if(modificationKind.equals("C")) {
-			return ontoModel.getIndividual(gitOntologyNamespace + "Copy");
+			return ontoModel.getIndividual(ONTOLOGY_GIT_NAMESPACE + "Copy");
 		}
 		else if(modificationKind.equals("R")) {
-			return ontoModel.getIndividual(gitOntologyNamespace + "Rename");
+			return ontoModel.getIndividual(ONTOLOGY_GIT_NAMESPACE + "Rename");
 		}
 		else {
-			return ontoModel.getIndividual(gitOntologyNamespace + "Update");
+			return ontoModel.getIndividual(ONTOLOGY_GIT_NAMESPACE + "Update");
 		}
 	}
 	
@@ -201,39 +209,39 @@ public class GitOntClassesAndProperties {
 	}
 
 	public ObjectProperty isNewCopyOfProperty() {
-		return ontoModel.getObjectProperty(ontologyHistoryNamespace + "isNewCopyOf");
+		return ontoModel.getObjectProperty(ONTOLOGY_HISTORY_NAMESPACE + "isNewCopyOf");
 	}
 
 	public ObjectProperty copiesFileProperty() {
-		return ontoModel.getObjectProperty(ontologyHistoryNamespace + "copiesFile");
+		return ontoModel.getObjectProperty(ONTOLOGY_HISTORY_NAMESPACE + "copiesFile");
 	}
 
 	public ObjectProperty deletesFileProperty() {
-		return ontoModel.getObjectProperty(ontologyHistoryNamespace + "deletesFile");
+		return ontoModel.getObjectProperty(ONTOLOGY_HISTORY_NAMESPACE + "deletesFile");
 	}
 
 	public ObjectProperty isRenamedToProperty() {
-		return ontoModel.getObjectProperty(ontologyHistoryNamespace + "isRenamedTo");
+		return ontoModel.getObjectProperty(ONTOLOGY_HISTORY_NAMESPACE + "isRenamedTo");
 	}
 
 	public ObjectProperty renamesFileProperty() {
-		return ontoModel.getObjectProperty(ontologyHistoryNamespace + "renamesFile");
+		return ontoModel.getObjectProperty(ONTOLOGY_HISTORY_NAMESPACE + "renamesFile");
 	}
 
 	public ObjectProperty updatesFileProperty() {
-		return ontoModel.getObjectProperty(ontologyHistoryNamespace + "updatesFiles");
+		return ontoModel.getObjectProperty(ONTOLOGY_HISTORY_NAMESPACE + "updatesFiles");
 	}
 
 	public ObjectProperty hasParentProperty() {
-		return ontoModel.getObjectProperty(ontologyMainNamespace + "hasParent");
+		return ontoModel.getObjectProperty(ONTOLOGY_MAIN_NAMESPACE + "hasParent");
 	}
 
 	public ObjectProperty atCommitProperty() {
-		return ontoModel.getObjectProperty(gitOntologyNamespace + "tagAtCommit");
+		return ontoModel.getObjectProperty(ONTOLOGY_GIT_NAMESPACE + "tagAtCommit");
 	}
 
 	public ObjectProperty hasTagProperty() {
-		return ontoModel.getObjectProperty(gitOntologyNamespace + "hasTag");
+		return ontoModel.getObjectProperty(ONTOLOGY_GIT_NAMESPACE + "hasTag");
 	}
 
 	

--- a/owlify-git/src/main/java/scanner/GitOntologyTransformer.java
+++ b/owlify-git/src/main/java/scanner/GitOntologyTransformer.java
@@ -253,4 +253,16 @@ public class GitOntologyTransformer extends AbstractOwlifyComponent {
 		transformer.transform();
 	}
 
+	@Override
+	public Map<String, String> getProvidedNamespaces() {
+		// TODO Auto-generated method stub
+		HashMap<String, String> res = new HashMap<>();
+		res.put("git", ontClassesAndProperties.getOntologyNamespace());
+		res.put("main", ontClassesAndProperties.getMainNamespace());
+		res.put("history", ontClassesAndProperties.getHistoryNamespace());
+		
+		return res;
+	}
+
+	
 }

--- a/owlify-main/src/main/java/core/OwlifyComponent.java
+++ b/owlify-main/src/main/java/core/OwlifyComponent.java
@@ -1,10 +1,18 @@
 package core;
 
 import java.util.List;
+import java.util.Map;
 
 public interface OwlifyComponent {
 	public void transform();
 	public String getResultPath();
 	public List<String> getSourcePaths();
 	public void addSourcePath(String path);
+	
+	/**
+	 * @return 
+	 * 	Returns a map which contains all OWL namespaces which are provided by the component.
+	 * 	The keys are the abbreviations, and the values are the full URIs of these namespaces.
+	 */
+	public Map<String, String> getProvidedNamespaces();
 }

--- a/owlify-maven/src/main/java/MavenOntClasses.java
+++ b/owlify-maven/src/main/java/MavenOntClasses.java
@@ -24,6 +24,11 @@ public class MavenOntClasses {
 		return ontologyNamespace;
 	}
 
+	public String getOntologyMainNamespace() {
+		return ontologyMainNamespace;
+	}
+
+	
 	public OntModel getOntoModel() {
 		return ontoModel;
 	}

--- a/owlify-maven/src/main/java/MavenPOMFileParser.java
+++ b/owlify-maven/src/main/java/MavenPOMFileParser.java
@@ -6,7 +6,9 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.ontology.Individual;
@@ -184,6 +186,14 @@ public class MavenPOMFileParser extends AbstractOwlifyComponent {
 				System.out.println(file.getName());
 			}
 		}
+	}
+
+	@Override
+	public Map<String, String> getProvidedNamespaces() {
+		Map<String, String> res = new HashMap<>();
+		res.put("maven", ontClasses.getOntologyNamespace());
+		res.put("main", ontClasses.getOntologyMainNamespace());
+		return res;
 	}
 
 }

--- a/rule-based-mapping/src/main/java/api/ExecuteMappingAPIImpl.java
+++ b/rule-based-mapping/src/main/java/api/ExecuteMappingAPIImpl.java
@@ -20,7 +20,7 @@ class ExecuteMappingAPIImpl implements ExecuteMappingAPI {
 
 	public void setReasoningConfiguration(ReasoningConfiguration config, String outputFilePath) {
 		this.config = config;
-		this.reasoningResultPath = outputFilePath; //"./mapped.owl";
+		this.reasoningResultPath = outputFilePath;
 	}
 
 	public void executeMapping() throws FileNotFoundException {

--- a/rule-specification/src/main/java/asciidocparser/AsciiDocArc42Parser.java
+++ b/rule-specification/src/main/java/asciidocparser/AsciiDocArc42Parser.java
@@ -33,27 +33,51 @@ public class AsciiDocArc42Parser
     private final static String OWL_EXTENSION = ".owl";
     private final static String PREFIX = "tmp";
 
-    private final static String javaOntologyNamespace = "@prefix java: <http://arch-ont.org/ontologies/javacodeontology.owl#>\n";
-    private final static String famixNamespace = "@prefix famix: <http://arch-ont.org/ontologies/famix.owl#>\n";
-    private final static String mavenOntologyNamespace = "@prefix maven: <http://arch-ont.org/ontologies/maven.owl#>\n";
-    private final static String mainOntologyNamespace = "@prefix main: <http://arch-ont.org/ontologies/main.owl#>\n";
-    private final static String osgiOntologyNamespace = "@prefix osgi: <http://arch-ont.org/ontologies/osgi.owl#>\n";
-    private final static String historyOntologyNamespace = "@prefix git: <http://www.arch-ont.org/ontologies/git.owl#>\n";
-    private final static String architectureOntologyNamespace = "@prefix architecture: <http://www.arch-ont.org/ontologies/architecture.owl#>\n\n";
+//    private final static String javaOntologyNamespace = "@prefix java: <http://arch-ont.org/ontologies/javacodeontology.owl#>\n";
+//    private final static String famixNamespace = "@prefix famix: <http://arch-ont.org/ontologies/famix.owl#>\n";
+//    private final static String mavenOntologyNamespace = "@prefix maven: <http://arch-ont.org/ontologies/maven.owl#>\n";
+//    private final static String mainOntologyNamespace = "@prefix main: <http://arch-ont.org/ontologies/main.owl#>\n";
+//    private final static String osgiOntologyNamespace = "@prefix osgi: <http://arch-ont.org/ontologies/osgi.owl#>\n";
+//    private final static String historyOntologyNamespace = "@prefix git: <http://www.arch-ont.org/ontologies/git.owl#>\n";
+//    private final static String architectureOntologyNamespace = "@prefix architecture: <http://www.arch-ont.org/ontologies/architecture.owl#>\n\n";
+//
+//    private final static String ONTOLOGY_PREFIXES_FOR_MAPPING = famixNamespace
+//            + javaOntologyNamespace + mavenOntologyNamespace
+//            + mainOntologyNamespace + osgiOntologyNamespace
+//            + historyOntologyNamespace + architectureOntologyNamespace;
 
-    private final static String ONTOLOGY_PREFIXES_FOR_MAPPING = famixNamespace
-            + javaOntologyNamespace + mavenOntologyNamespace
-            + mainOntologyNamespace + osgiOntologyNamespace
-            + historyOntologyNamespace + architectureOntologyNamespace;
-
+    private final String ONTOLOGY_PREFIXES_FOR_MAPPING;
+    
     private static int id = 0;
 
     private List<String> ontologyPaths;
 
-    public AsciiDocArc42Parser()
+    /**
+     * Constructor.
+     * @param ontologyNamespaces 
+     * 	A map that maps abbreviation of OWL namespaces to the full URI of the namespace. 
+     * 	The map defines which abbreviations can be used in the processes .adoc files.
+     */
+    public AsciiDocArc42Parser(Map<String, String> ontologyNamespaces)
     {
+    	ONTOLOGY_PREFIXES_FOR_MAPPING = generatePrefix(ontologyNamespaces);
         ontologyPaths = new ArrayList<String>();
     }
+
+	private String generatePrefix(Map<String, String> ontologyNamespaces) {
+		StringBuilder builder = new StringBuilder();
+    	
+    	for (String abbreviation : ontologyNamespaces.keySet()) {
+    		builder.append("@prefix ");
+    		builder.append(abbreviation);
+    		builder.append(": <");
+    		builder.append(ontologyNamespaces.get(abbreviation));
+    		builder.append(">\n");
+    	}
+    	
+    	String res = builder.toString();
+		return res;
+	}
 
     /**
      * Search .adoc-file for keywords "rule" and "mapping"
@@ -191,9 +215,6 @@ public class AsciiDocArc42Parser
             for (String line : lines)
             {
                 tmp += line;
-
-                // TODO forward to JENA reasoner
-
             }
             System.out.println("[" + tmp + "]");
             allMappingRules += "[" + tmp + "]" + "\n";


### PR DESCRIPTION
The hard-coded OWL prefixes from the `conformancechecking-documentation` module have been replaced by a more flexible approach. Each module that provides some OWL namespace has a method to query them now, and the tool chain passes them to `conformancechecking-documentation`.