### PR TITLE
Replace string with path

### DIFF
--- a/cnl-toolchain/src/main/java/cnltoolchain/CNLToolchain.java
+++ b/cnl-toolchain/src/main/java/cnltoolchain/CNLToolchain.java
@@ -3,6 +3,9 @@ package cnltoolchain;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -78,7 +81,8 @@ public class CNLToolchain {
 		LOG.info("CNLToolchain initialized.");
 
 		try {
-			tool.execute(rulesFile, projectPath, context);
+			Path rulesPath = Paths.get(rulesFile);
+			tool.execute(rulesPath, projectPath, context);
 		} catch (FileNotFoundException e) {
 			LOG.error("File not found", e);
 			// TODO Auto-generated catch block
@@ -110,9 +114,13 @@ public class CNLToolchain {
 	 * @throws NoConnectionToStardogServerException when no connection to the
 	 *                                              database can be established
 	 */
-	private void execute(String docPath, String sourceCodePath, String context)
+	private void execute(Path docPath, String sourceCodePath, String context)
 			throws FileNotFoundException, NoConnectionToStardogServerException {
 		LOG.info("Starting the execution");
+		
+		if(Files.notExists(docPath)) {
+			throw new FileNotFoundException("The rules file could not be found: " + docPath);
+		}
 
 		createTemporaryDirectory();
 
@@ -225,7 +233,7 @@ public class CNLToolchain {
 		return codeModelPath;
 	}
 
-	private List<ArchitectureRule> parseRuleFile(String docPath) {
+	private List<ArchitectureRule> parseRuleFile(Path docPath) {
 		LOG.info("Parsing the rule file ...");
 		AsciiDocArc42Parser parser = new AsciiDocArc42Parser(gatherOWLNamespaces());
 		LOG.debug("Parsing the architecture rules ...");

--- a/cnl-toolchain/src/main/java/cnltoolchain/CNLToolchain.java
+++ b/cnl-toolchain/src/main/java/cnltoolchain/CNLToolchain.java
@@ -67,7 +67,7 @@ public class CNLToolchain {
 	 * @param password    The password to use when connecting to the database server. 
 	 * @param projectDirectory The path to the root of the project which should be
 	 *                    analysed.
-	 * @param rulesFile   The path to the AsciiDoc file which contains both the
+	 * @param rulesFile   The relative path to the AsciiDoc file which contains both the
 	 *                    architecture and mapping rules.
 	 */
 	public static void runToolchain(String database, String server, String context, 
@@ -83,7 +83,7 @@ public class CNLToolchain {
 
 		try {
 			Path projectPath = Paths.get(projectDirectory);
-			Path rulesPath = Paths.get(rulesFile);
+			Path rulesPath = Paths.get(projectDirectory, rulesFile);
 			tool.execute(rulesPath, projectPath, context);
 		} catch (FileNotFoundException e) {
 			LOG.error("File not found", e);

--- a/cnl-toolchain/src/main/java/cnltoolchain/CNLToolchainCLI.java
+++ b/cnl-toolchain/src/main/java/cnltoolchain/CNLToolchainCLI.java
@@ -31,7 +31,7 @@ public class CNLToolchainCLI implements Runnable {
 	
 	@Override
 	public void run() {
-        CNLToolchain.runToolchain(database, server, context, username, password, projectPath, projectPath + rulesFile);
+        CNLToolchain.runToolchain(database, server, context, username, password, projectPath, rulesFile);
 	}
 	
 	public static void main(String[] args) {

--- a/owlify-famix/src/main/java/parser/FamixOntologyTransformer.java
+++ b/owlify-famix/src/main/java/parser/FamixOntologyTransformer.java
@@ -2,6 +2,8 @@ package parser;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,8 +70,8 @@ public class FamixOntologyTransformer extends AbstractOwlifyComponent {
 		
 		CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
 		combinedTypeSolver.add(new ReflectionTypeSolver());
-		List<String> sourcePaths = super.getSourcePaths();
-		for (String path : sourcePaths) {
+		List<Path> sourcePaths = super.getSourcePaths();
+		for (Path path : sourcePaths) {
 			LOG.debug("Adding Java source path: " + path);
 			combinedTypeSolver.add(new JavaParserTypeSolver(path));
 		}
@@ -85,10 +87,10 @@ public class FamixOntologyTransformer extends AbstractOwlifyComponent {
 		ontology.save(super.getResultPath());
 	}
 
-	private void parseOtherElements(List<String> sourcePaths) {
+	private void parseOtherElements(List<Path> sourcePaths) {
 		LOG.trace("Starting parseOtherElements ...");
-		for (String path : sourcePaths) {
-			for (File file : FileUtils.listFiles(new File(path),
+		for (Path path : sourcePaths) {
+			for (File file : FileUtils.listFiles(path.toFile(),
 					new WildcardFileFilter(ProgrammingLanguage.getFileExtensionWildCard(ProgrammingLanguage.JAVA)),
 					TrueFileFilter.INSTANCE)) {
 				LOG.debug("Parsing code file: " + file.getAbsolutePath());
@@ -122,9 +124,9 @@ public class FamixOntologyTransformer extends AbstractOwlifyComponent {
 		}
 	}
 
-	private void resolveAllTypes(List<String> sourcePaths) {
-		for (String path : sourcePaths) {
-			for (File file : FileUtils.listFiles(new File(path),
+	private void resolveAllTypes(List<Path> sourcePaths) {
+		for (Path path : sourcePaths) {
+			for (File file : FileUtils.listFiles(path.toFile(),
 					new WildcardFileFilter(ProgrammingLanguage.getFileExtensionWildCard(ProgrammingLanguage.JAVA)),
 					TrueFileFilter.INSTANCE)) {
 				CompilationUnit unit;

--- a/owlify-famix/src/test/java/parser/FamixOntologyTransformerTest.java
+++ b/owlify-famix/src/test/java/parser/FamixOntologyTransformerTest.java
@@ -6,6 +6,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
 
@@ -27,7 +28,8 @@ public class FamixOntologyTransformerTest {
 	@Test
 	public void testCoarse() throws IOException {
 		FamixOntologyTransformer famixTransformer = new FamixOntologyTransformer("./src/test/resources/results.owl");
-		famixTransformer.addSourcePath("./src/test/resources/project");
+		Path testSourcePath = Paths.get("./src/test/resources/project");
+		famixTransformer.addSourcePath(testSourcePath);
         famixTransformer.transform();
         
         // The output ontology contains some "tags" <hasPath> ... </hasPath> which contain

--- a/owlify-main/src/main/java/core/AbstractOwlifyComponent.java
+++ b/owlify-main/src/main/java/core/AbstractOwlifyComponent.java
@@ -1,5 +1,6 @@
 package core;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,7 +14,7 @@ public abstract class AbstractOwlifyComponent implements OwlifyComponent {
 	private String resultPath;
 	
 	// list of input paths
-	private List<String> sourcePaths;
+	private List<Path> sourcePaths;
 	
 	/**
 	 * Constructor.
@@ -21,14 +22,14 @@ public abstract class AbstractOwlifyComponent implements OwlifyComponent {
 	 */
 	public AbstractOwlifyComponent(String resultPath) {
 		this.resultPath = resultPath;
-		this.sourcePaths = new ArrayList<String>();
+		this.sourcePaths = new ArrayList<Path>();
 	}
 
-	public void addSourcePath(String path) {
+	public void addSourcePath(Path path) {
 		sourcePaths.add(path);
 	}
 	
-	public List<String> getSourcePaths(){		
+	public List<Path> getSourcePaths(){		
 		return sourcePaths;
 	}
 

--- a/owlify-main/src/main/java/core/OwlifyComponent.java
+++ b/owlify-main/src/main/java/core/OwlifyComponent.java
@@ -1,5 +1,6 @@
 package core;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -25,13 +26,13 @@ public interface OwlifyComponent {
 	/**
 	 * Returns a list of input file/directory path's which have been added in the past.
 	 */
-	public List<String> getSourcePaths();
+	public List<Path> getSourcePaths();
 	
 	/**
 	 * Adds a file (or directory) to this parser's inputs.
 	 * @param path the path of the file/directory to add
 	 */
-	public void addSourcePath(String path);
+	public void addSourcePath(Path path);
 	
 	/**
 	 * @return 

--- a/rule-specification/src/main/java/asciidocparser/AsciiDocArc42Parser.java
+++ b/rule-specification/src/main/java/asciidocparser/AsciiDocArc42Parser.java
@@ -3,9 +3,7 @@ package asciidocparser;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -83,7 +81,7 @@ public class AsciiDocArc42Parser {
 	 *                        (without a slash (/) at the end)
 	 * @return The list of architecture rules from the rule file.
 	 */
-	public List<ArchitectureRule> parseRulesFromDocumentation(String path, String outputDirectory) {
+	public List<ArchitectureRule> parseRulesFromDocumentation(Path path, String outputDirectory) {
 		LOG.trace("Starting parseRulesFromDocumentation ...");
 		LOG.debug("Parsing architecture rules from file: " + path);
 
@@ -146,10 +144,9 @@ public class AsciiDocArc42Parser {
 		}
 	}
 
-	private List<StructuralNode> parseAsciidocFile(String path, String tag) {
+	private List<StructuralNode> parseAsciidocFile(Path path, String tag) {
 		Asciidoctor ascii = Asciidoctor.Factory.create();
-		File file = new File(path);
-		Document doc = ascii.loadFile(file, new HashMap<String, Object>());
+		Document doc = ascii.loadFile(path.toFile(), new HashMap<String, Object>());
 		Map<Object, Object> selector = new HashMap<Object, Object>();
 		selector.put("role", tag);
 		List<StructuralNode> result = doc.findBy(selector);
@@ -163,7 +160,7 @@ public class AsciiDocArc42Parser {
 	 * @param outputFile - Path where the resulting ontology file (.owl) will be
 	 *                   stored.
 	 */
-	public void parseMappingRulesFromDocumentation(String path, String outputFile) {
+	public void parseMappingRulesFromDocumentation(Path path, String outputFile) {
 		LOG.trace("Starting parseMappingRulesFromDocumentation ...");
 
 		LOG.debug("Parsing mapping rules from file: " + path);

--- a/rule-specification/src/test/java/asciidocparser/AsciiDocArc42ParserTest.java
+++ b/rule-specification/src/test/java/asciidocparser/AsciiDocArc42ParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,8 +30,9 @@ public class AsciiDocArc42ParserTest {
 		namespaces.put("architecture", "http://www.arch-ont.org/ontologies/architecture.owl#");
 		AsciiDocArc42Parser parser = new AsciiDocArc42Parser(namespaces);
 		
-		List<ArchitectureRule> rules = parser.parseRulesFromDocumentation("./src/test/resources/rules.adoc", "./src/test/resources");
-        parser.parseMappingRulesFromDocumentation("./src/test/resources/rules.adoc", "./src/test/resources/mapping.txt");
+		Path testRulesPath = Paths.get("./src/test/resources/rules.adoc");
+		List<ArchitectureRule> rules = parser.parseRulesFromDocumentation(testRulesPath, "./src/test/resources");
+        parser.parseMappingRulesFromDocumentation(testRulesPath, "./src/test/resources/mapping.txt");
         
         
         // assert that the extracted rules are correct


### PR DESCRIPTION
Replace the path, which is hold as string, with `java.nio.file.Path`.
This allows for understandable error checking on the rule and project path.
Also, this solves #83 .