### PR TITLE
Update asciidoctorj to avoid warning

### DIFF
--- a/architecture-description-parser/pom.xml
+++ b/architecture-description-parser/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.asciidoctor</groupId>
 			<artifactId>asciidoctorj</artifactId>
-			<version>2.1.0</version>
+			<version>2.4.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.architecture.cnl</groupId>


### PR DESCRIPTION
This pull request updates the asciidoctorj dependency to avoid the following warning while executing the toolchain:
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.headius.backport9.modules.Modules (file:/Users/vhs/.m2/repository/com/headius/backport9/1.2/backport9-1.2.jar) to field java.io.FileDescriptor.fd
WARNING: Please consider reporting this to the maintainers of com.headius.backport9.modules.Modules
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```