### PR TITLE
fixed use of restricted characters in famix uris

### DIFF
--- a/owlify-famix/src/main/java/org/archcnl/owlify/famix/codemodel/Method.java
+++ b/owlify-famix/src/main/java/org/archcnl/owlify/famix/codemodel/Method.java
@@ -138,10 +138,8 @@ public class Method {
      * @param parent The individual of the type in which this method is defined.
      */
     public void modelIn(FamixOntology ontology, String parentName, Individual parent) {
-        String uriBase = parentName + "." + signature;
-        // replace the array "marker" [] with (Array), because [] are no valid URI characters
-        final String uri = uriBase.replace("[]", "(Array)").replace(" ", "");
-
+        final String uri = parentName + "." + signature;
+        
         Individual m = ontology.createIndividual(FamixClasses.Method, uri);
 
         m.addLiteral(ontology.get(hasName), name);

--- a/owlify-famix/src/main/java/org/archcnl/owlify/famix/ontology/FamixOntology.java
+++ b/owlify-famix/src/main/java/org/archcnl/owlify/famix/ontology/FamixOntology.java
@@ -55,6 +55,12 @@ public class FamixOntology {
         codeModel.read(famixOntology, null);
     }
 
+    /**
+     * Creates a new individual of the given ontology class.
+     * @param clazz The ontology class to which the individual will belong.
+     * @param uri The "base name" of the individual's URI. Invalid characters will be displayed in percent-notation. Spaces will be replaced by a -. Also, the class will be added as a prefix. No other individual of the same class should have this name.
+     * @return The created individual.
+     */
     public Individual createIndividual(FamixClasses clazz, String uri) {
         return clazz.createIndividual(codeModel, uri);
     }
@@ -89,12 +95,36 @@ public class FamixOntology {
             return model.getOntClass(uri()).createIndividual(individualUri(name));
         }
 
+        private String replaceSpecialCharacters(String name) {
+            // uses percent-notation, replaces spaces by '-'
+            return name.replace(" ", "-")
+                    .replace("%", "%25") // must be before the replacements using %
+                    .replace("!", "%21")
+                    .replace("#", "%23")
+                    .replace("$", "%24")
+                    .replace("&", "%26")
+                    .replace("'", "%27")
+                    .replace("(", "%28")
+                    .replace(")", "%29")
+                    .replace("*", "%2A")
+                    .replace("+", "%2B")
+                    .replace(",", "%2C")
+                    .replace("/", "%2F")
+                    .replace(":", "%3A")
+                    .replace(";", "%3B")
+                    .replace("=", "%3D")
+                    .replace("?", "%3F")
+                    .replace("@", "%40")
+                    .replace("[", "%5B")
+                    .replace("]", "%5D");
+        }
+        
         public String uri() {
             return PREFIX + this.name();
         }
 
         public String individualUri(String name) {
-            return this.uri() + "/" + name;
+            return this.uri() + "/" + replaceSpecialCharacters(name);
         }
     }
 

--- a/owlify-famix/src/test/java/org/archcnl/owlify/famix/ontology/FamixOntologyTest.java
+++ b/owlify-famix/src/test/java/org/archcnl/owlify/famix/ontology/FamixOntologyTest.java
@@ -1,0 +1,37 @@
+package org.archcnl.owlify.famix.ontology;
+
+import static org.junit.Assert.*;
+
+import org.archcnl.owlify.famix.ontology.FamixOntology.FamixClasses;
+import org.junit.Test;
+
+public class FamixOntologyTest {
+
+    private final FamixClasses clazz = FamixClasses.Attribute;
+    private final String prefix = clazz.uri() + "/";
+    
+    @Test
+    public void testNameGenerationSimple() {
+        String actual = clazz.individualUri("Easy");
+        String expected = prefix + "Easy";
+        
+        assertEquals(expected, actual);
+    }
+    
+    @Test
+    public void testNameGenerationSpaces() {
+        String actual = clazz.individualUri("The next string is pretty weird");
+        String expected = prefix + "The-next-string-is-pretty-weird";
+        
+        assertEquals(expected, actual);
+    }
+    
+    @Test
+    public void testNameGenerationReservedCharacters() {
+        String actual = clazz.individualUri("Reserved!#$&'()*+,/:;=?@[]");
+        String expected = prefix + "Reserved%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D";
+        
+        assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
- using percent notation/uri encoding
- spaces are replaced by minus signs

closes #120 