### PR TITLE
Add multiple source paths

### DIFF
--- a/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchainCLI.java
+++ b/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchainCLI.java
@@ -1,5 +1,6 @@
 package org.archcnl.toolchain;
 
+import java.util.List;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -23,14 +24,15 @@ public class CNLToolchainCLI implements Runnable {
             description = "Specifiy the context")
     private String context = "http://graphs.org/" + database + "/1.0";
 
+    @Parameters(paramLabel = "<rules file>", description = "The path to the rules", index = "0")
+    private String rulesFile;
+
     @Parameters(
             paramLabel = "<project path>",
             description =
-                    "The path to the project's Java source code root directory (usually some kind of \"src\" folder)")
-    private String projectPath;
-
-    @Parameters(paramLabel = "<rules file>", description = "The path to the rules")
-    private String rulesFile;
+                    "One or more paths to the project's Java source code root directory (usually some kind of \"src\" folder)",
+            index = "1..*")
+    private List<String> projectPaths;
 
     @Option(
             names = {"-u", "--username"},
@@ -60,7 +62,7 @@ public class CNLToolchainCLI implements Runnable {
                 context,
                 username,
                 password,
-                projectPath,
+                projectPaths,
                 rulesFile,
                 logVerbose,
                 removePreviousDatabases);


### PR DESCRIPTION
A java project could consist of multiple source paths.
For example, ArchCNL itself consists of multiple maven modules.
Since the javaparser needs a path to the `src` directory to resolve all symbols, that would require multiple runs of ArchCNL to analyze its source if #113 would be implemented.
The solution this pull request provides is to add multiple source paths in one run. The `OwlifyComponent`-Interface already [uses a list of source paths](https://github.com/Mari-Wie/ArchCNL/blob/e5e816ffeb6dc7e2e0162ad3b13fac0869cbd4fc/owlify/src/main/java/org/archcnl/owlify/core/OwlifyComponent.java#L21), so it is only a matter of providing them from the cli.