### PR TITLE
improved cli argument descriptions

### DIFF
--- a/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchainCLI.java
+++ b/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchainCLI.java
@@ -30,7 +30,7 @@ public class CNLToolchainCLI implements Runnable {
     @Parameters(
             paramLabel = "<project path>",
             description =
-                    "One or more paths to the project's Java source code root directory (usually some kind of \"src\" folder)",
+                    "One or more paths to the project's source code root directories (usually some kind of \"src\" folder)",
             index = "1..*")
     private List<String> projectPaths;
 


### PR DESCRIPTION
- closes #145
- sourcepaths argument's description now refers to all source paths and not just java ones