### PR TITLE
Catch errors thrown by javaparser on external exceptions

### DIFF
--- a/java-parser/src/main/java/org/archcnl/javaparser/visitors/ThrowStatementVisitor.java
+++ b/java-parser/src/main/java/org/archcnl/javaparser/visitors/ThrowStatementVisitor.java
@@ -48,7 +48,7 @@ public class ThrowStatementVisitor extends VoidVisitorAdapter<Void> {
             } catch (UnsupportedOperationException e) {
                 LOG.error("Can not calculate type of " + throwExpression, e);
             } catch (UnsolvedSymbolException e) {
-                LOG.error("Can not solve symbole of " + throwExpression, e);
+                LOG.error("Can not solve symbol of " + throwExpression, e);
             } catch (RuntimeException e) {
                 LOG.error(
                         "An exception was used that javaparser can not reach: " + throwExpression,

--- a/java-parser/src/main/java/org/archcnl/javaparser/visitors/ThrowStatementVisitor.java
+++ b/java-parser/src/main/java/org/archcnl/javaparser/visitors/ThrowStatementVisitor.java
@@ -3,6 +3,7 @@ package org.archcnl.javaparser.visitors;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.ThrowStmt;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
@@ -46,6 +47,12 @@ public class ThrowStatementVisitor extends VoidVisitorAdapter<Void> {
                         new Type(typeName, simpleName, false); // primitives types cannot be thrown
             } catch (UnsupportedOperationException e) {
                 LOG.error("Can not calculate type of " + throwExpression, e);
+            } catch (UnsolvedSymbolException e) {
+                LOG.error("Can not solve symbole of " + throwExpression, e);
+            } catch (RuntimeException e) {
+                LOG.error(
+                        "An exception was used that javaparser can not reach: " + throwExpression,
+                        e);
             }
         }
 

--- a/java-parser/src/test/java/org/archcnl/javaparser/visitors/ThrowStatementVisitorTest.java
+++ b/java-parser/src/test/java/org/archcnl/javaparser/visitors/ThrowStatementVisitorTest.java
@@ -55,6 +55,14 @@ public class ThrowStatementVisitorTest extends GenericVisitorTest<ThrowStatement
         assertTrue(exceptions.contains("IllegalStateException"));
     }
 
+    /*
+     * This test uses a specific class, where an external exception is thrown.
+     * An external exception is an exception, that is not inside the path analyzed by the javaparser.
+     * The javaparser fails with either a UnsolvedSymbolException or a RuntimeException,
+     *  depending on the type of usage.
+     * This test is to verify, that this error is logged but does not stop the execution.
+     * That is why it is expected, that no exceptions are found.
+     */
     @Test
     public void testTryCatchThrow() throws FileIsNotAJavaClassException, FileNotFoundException {
         final CompilationUnit unit = CompilationUnitFactory.getFromPath(pathToTryCatchThrowClass);

--- a/java-parser/src/test/java/org/archcnl/javaparser/visitors/ThrowStatementVisitorTest.java
+++ b/java-parser/src/test/java/org/archcnl/javaparser/visitors/ThrowStatementVisitorTest.java
@@ -17,6 +17,9 @@ public class ThrowStatementVisitorTest extends GenericVisitorTest<ThrowStatement
             GenericVisitorTest.PATH_TO_PACKAGE_WITH_TEST_EXAMPLES
                     + "ExampleClassWithExceptions.java";
 
+    private String pathToTryCatchThrowClass =
+            GenericVisitorTest.PATH_TO_PACKAGE_WITH_TEST_EXAMPLES + "TryCatchThrow.java";
+
     @Test
     public void testFullyQualifiedNames()
             throws FileIsNotAJavaClassException, FileNotFoundException {
@@ -50,6 +53,17 @@ public class ThrowStatementVisitorTest extends GenericVisitorTest<ThrowStatement
         assertEquals(2, exceptions.size());
         assertTrue(exceptions.contains("IllegalArgumentException"));
         assertTrue(exceptions.contains("IllegalStateException"));
+    }
+
+    @Test
+    public void testTryCatchThrow() throws FileIsNotAJavaClassException, FileNotFoundException {
+        final CompilationUnit unit = CompilationUnitFactory.getFromPath(pathToTryCatchThrowClass);
+
+        unit.accept(visitor, null);
+
+        final List<Type> exceptions = visitor.getThrownExceptionType();
+
+        assertEquals(0, exceptions.size());
     }
 
     @Override

--- a/java-parser/src/test/resources/examples/TryCatchThrow.java
+++ b/java-parser/src/test/resources/examples/TryCatchThrow.java
@@ -1,0 +1,20 @@
+package examples;
+
+public class EmptyClass {
+    private Exception transform(MyExternalIndexOutOfBoundsException ex){
+        return new Exception(ex.getMessage());
+    }
+
+    public void doStuff() throws Exception {
+        try {
+            int[] myNumbers = {1, 2, 3};
+            int num = myNumbers[10];
+        } catch (MyExternalIndexOutOfBoundsException e) {
+            throw transform(e);
+        }
+    }
+
+    public void doOtherStuff() throws Exception {
+        throw new MyExternalIndexOutOfBoundsException(e);
+    }
+}


### PR DESCRIPTION
Exceptions, that are not contained in the source folder that is passed to javaparser, would be considered external exceptions.
Javaparser can not solve their type if they are thrown or used as an argument.
But that should not stop the entire parsing process.

The solution, that is proposed here, is to catch these errors and log them. They are not added as type, since their type can not be resolved.

An example for such a problem are [some parts of the Corona-Warn-App](https://github.com/corona-warn-app/cwa-server/blob/6ba1b4750a8073063ae16cad91102a63b44932f8/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/RemoteStatisticJsonFileLoader.java#L61). But throwing an exception of a type that comes from an external library should not be too uncommon.