### PR TITLE
Update surefire plugin to support JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<apachejenaVersion>3.3.0</apachejenaVersion>
 		<owlapiVersion>5.1.0</owlapiVersion>
 		<junitVersion>4.12</junitVersion>
-		<surefireVersion>2.12.4</surefireVersion>
+		<surefireVersion>2.22.2</surefireVersion>
 		<spotlessVersion>2.9.0</spotlessVersion>
 		<antlr.version>4.9.2</antlr.version>
 		<buildHelperVersion>3.2.0</buildHelperVersion>


### PR DESCRIPTION
As @VincentRaudszus pointed out to me, the current surefire plugin is too old to detect and execute the JUnit 5 tests in the kotlin parser.
With this version, the seven tests in the kotlin parser are executed.

The result of `mvn verify --projects kotlin-parser -am`:
```
[INFO] --- maven-surefire-plugin:2.22.2:test (default-test) @ kotlin-parser ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.archcnl.kotlinparser.visitor.KotlinTypeVisitorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.137 s - in org.archcnl.kotlinparser.visitor.KotlinTypeVisitorTest
[INFO] Running org.archcnl.kotlinparser.visitor.ImportDeclarationVisitorTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s - in org.archcnl.kotlinparser.visitor.ImportDeclarationVisitorTest
[INFO] Running org.archcnl.kotlinparser.visitor.NamespaceVisitorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s - in org.archcnl.kotlinparser.visitor.NamespaceVisitorTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
```