### PR TITLE
ARCHCNL-14: Pipeline should fail when coverage < 90%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 		<antlr.version>4.9.2</antlr.version>
 		<buildHelperVersion>3.2.0</buildHelperVersion>
 		<failsafeVersion>2.22.0</failsafeVersion>
+		<jacocoVersion>0.8.7</jacocoVersion>
 	</properties>
 
 	<profiles>
@@ -144,6 +145,48 @@
 						<goal>verify</goal>
 					</goals>
 				</execution>
+			</executions>
+		</plugin>
+		<!-- Jacoco plugin: Checks if code coverage requirements are fulfilled -->
+		<plugin>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<version>${jacocoVersion}</version>
+			<executions>
+				<execution>
+					<goals>
+						<goal>prepare-agent</goal>
+					</goals>
+				</execution>
+				<execution>
+					<id>jacoco-report</id>
+					<phase>test</phase>
+					<goals>
+						<goal>report</goal>
+					</goals>
+				</execution>
+				<execution>
+					<id>jacoco-check</id>
+					<goals>
+						<goal>check</goal>
+					</goals>
+					<configuration>
+						<haltOnFailure>false</haltOnFailure>
+						<rules>
+							<rule>
+								<element>BUNDLE</element>
+								<limits>
+									<limit>
+										<counter>BRANCH</counter>
+										<value>COVEREDRATIO</value>
+										<minimum>90%</minimum>
+									</limit>
+								</limits>
+							</rule>
+						</rules>
+					</configuration>
+				</execution>
+
 			</executions>
 		</plugin>
 		</plugins>


### PR DESCRIPTION
- Added Jacoco plugin to check coverage in pipeline