### PR TITLE
ARCHCNL-14: Pipeline should fail when coverage < 90%

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,5 +18,5 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Build with Maven
-        run: mvn -P github-ci -B package --file pom.xml
+      - name: Verify with Maven (but skip integration tests)
+        run: mvn -P github-ci -B verify --file pom.xml -DskipITs=true

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 		<antlr.version>4.9.2</antlr.version>
 		<buildHelperVersion>3.2.0</buildHelperVersion>
 		<failsafeVersion>2.22.0</failsafeVersion>
+		<jacocoVersion>0.8.7</jacocoVersion>
 	</properties>
 
 	<profiles>
@@ -144,6 +145,48 @@
 						<goal>verify</goal>
 					</goals>
 				</execution>
+			</executions>
+		</plugin>
+		<!-- Jacoco plugin: Checks if code coverage requirements are fulfilled -->
+		<plugin>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<version>${jacocoVersion}</version>
+			<executions>
+				<execution>
+					<goals>
+						<goal>prepare-agent</goal>
+					</goals>
+				</execution>
+				<execution>
+					<id>jacoco-report</id>
+					<phase>test</phase>
+					<goals>
+						<goal>report</goal>
+					</goals>
+				</execution>
+				<execution>
+					<id>jacoco-check</id>
+					<goals>
+						<goal>check</goal>
+					</goals>
+					<configuration>
+						<haltOnFailure>false</haltOnFailure>
+						<rules>
+							<rule>
+								<element>BUNDLE</element>
+								<limits>
+									<limit>
+										<counter>BRANCH</counter>
+										<value>COVEREDRATIO</value>
+										<minimum>90%</minimum>
+									</limit>
+								</limits>
+							</rule>
+						</rules>
+					</configuration>
+				</execution>
+
 			</executions>
 		</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,6 @@
 						</rules>
 					</configuration>
 				</execution>
-
 			</executions>
 		</plugin>
 		</plugins>


### PR DESCRIPTION
_Note: The CI pipeline failed due to the adjusted GitHub workflow. It should work once merged in the master branch (I tested it in my fork)._
- Added Jacoco plugin to test the test coverage as part of the CI pipeline. The plugin is currently set up to throw a warning when the branch coverage in any bundle / sub-project / module (whatever you want to call them) is below 90%. The pipeline will not fail because of this (we should change this once the 90% coverage goal is reached).
- In order to execute the Jacoco plugin the GitHub workflow needed to be adjusted as the plugin is only executed in the verify stage. This adjustment will not change the current functionality as the integration tests are manually excluded and the package command is executed as part of the maven verify command. 