### PR TITLE
ARCHCNL-32: Generated classes excluded from coverage check in pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
 			<groupId>org.jacoco</groupId>
 			<artifactId>jacoco-maven-plugin</artifactId>
 			<version>${jacocoVersion}</version>
+			<configuration>
+				<excludes>
+					<exclude>org/archcnl/kotlinparser/grammar/KotlinParser*.*</exclude>
+				</excludes>
+			</configuration>
 			<executions>
 				<execution>
 					<goals>


### PR DESCRIPTION
[KotlinParser.g4](https://github.com/Mari-Wie/ArchCNL/blob/master/kotlin-parser/src/main/antlr4/org/archcnl/kotlinparser/grammar/KotlinParser.g4) is not truly a generated class. However, it was also not written specifically for this project and was taken from https://kotlinlang.org/docs/reference/grammar.html. Only a small part of its functionality is actually used and tested within ArchCNL. Ensuring the sufficient test coverage of this parser is thus not within the scope of this project and should not be taken into account for the coverage checks within the pipeline,
There are two more files from the same source that I chose not to exclude for the following reasons:

- [KotlinLexer.g4](https://github.com/Mari-Wie/ArchCNL/blob/master/kotlin-parser/src/main/antlr4/org/archcnl/kotlinparser/grammar/KotlinLexer.g4): This file is still part of the coverage checks as the existent tests already cover 99% of its instructions and 100% of its branches.
- [UnicodeClasses.g4](https://github.com/Mari-Wie/ArchCNL/blob/master/kotlin-parser/src/main/antlr4/imports/UnicodeClasses.g4): This file was not excluded as it is not considered for the coverage checks either way (I am uncertain why this is the case).

Excluding [KotlinParser.g4](https://github.com/Mari-Wie/ArchCNL/blob/master/kotlin-parser/src/main/antlr4/org/archcnl/kotlinparser/grammar/KotlinParser.g4) from the coverage checks brings the branch coverage of the kotlin-parser module up to 85% from just 16%.