### PR TITLE
Do not access violation at an index that is greater than the list size

### DIFF
--- a/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
+++ b/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
@@ -21,6 +21,7 @@ import org.archcnl.architecturedescriptionparser.AsciiDocArc42Parser;
 import org.archcnl.architecturereasoning.api.ExecuteMappingAPI;
 import org.archcnl.architecturereasoning.api.ExecuteMappingAPIFactory;
 import org.archcnl.common.datatypes.ArchitectureRule;
+import org.archcnl.common.datatypes.ConstraintViolation;
 import org.archcnl.conformancechecking.api.CheckedRule;
 import org.archcnl.conformancechecking.api.IConformanceCheck;
 import org.archcnl.conformancechecking.impl.ConformanceCheckImpl;
@@ -66,12 +67,6 @@ public class CNLToolchain {
                         .map(name -> createTransformer(name))
                         .collect(Collectors.toList());
         this.check = new ConformanceCheckImpl();
-    }
-
-    private OwlifyComponent createTransformer(String name) {
-        var factory = transformerFactories.get(name);
-        if (factory == null) throw new RuntimeException("Unknown parser '" + name + "'");
-        return factory.get();
     }
 
     /**
@@ -152,6 +147,23 @@ public class CNLToolchain {
         Date date = Calendar.getInstance().getTime();
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd__'at'__HH-mm-ss_z");
         return dateFormat.format(date);
+    }
+
+    /*
+     * Match the databaseName to a regex provided by Stardog
+     *
+     * @see <a href="https://docs.stardog.com/operating-stardog/database-administration/database-configuration#databasename">Stardog Documentation</a>
+     */
+    private static boolean isDatabaseNameValid(String databaseName) {
+        var pattern = Pattern.compile("[A-Za-z]{1}[A-Za-z0-9_-]*");
+        var matcher = pattern.matcher(databaseName);
+        return matcher.matches();
+    }
+
+    private OwlifyComponent createTransformer(String name) {
+        var factory = transformerFactories.get(name);
+        if (factory == null) throw new RuntimeException("Unknown parser '" + name + "'");
+        return factory.get();
     }
 
     /**
@@ -255,8 +267,15 @@ public class CNLToolchain {
         check.createNewConformanceCheck();
         int ruleIndex = 0;
         for (ArchitectureRule rule : sucessfulRules) {
+            List<ConstraintViolation> violationsForRule;
+            if (ruleIndex < violations.size()) {
+                violationsForRule = violations.get(ruleIndex).getViolationList();
+            } else {
+                LOG.info("ruleIndex is greater than violation list size");
+                violationsForRule = new ArrayList<>();
+            }
 
-            CheckedRule vr = new CheckedRule(rule, violations.get(ruleIndex).getViolationList());
+            CheckedRule vr = new CheckedRule(rule, violationsForRule);
 
             if (!vr.getViolations().isEmpty()) {
                 LOG.info("The following rule is violated: " + vr.getRule().getCnlSentence());
@@ -329,16 +348,5 @@ public class CNLToolchain {
         supportedOWLNamespaces.put(
                 "architecture", "http://www.arch-ont.org/ontologies/architecture.owl#");
         return supportedOWLNamespaces;
-    }
-
-    /*
-     * Match the databaseName to a regex provided by Stardog
-     *
-     * @see <a href="https://docs.stardog.com/operating-stardog/database-administration/database-configuration#databasename">Stardog Documentation</a>
-     */
-    private static boolean isDatabaseNameValid(String databaseName) {
-        var pattern = Pattern.compile("[A-Za-z]{1}[A-Za-z0-9_-]*");
-        var matcher = pattern.matcher(databaseName);
-        return matcher.matches();
     }
 }


### PR DESCRIPTION
In the context of #176 there could be a problem, where the size of the list of violations is unequal to the size of the rules.

Since the violations are accessed by the rule index, this can lead to a problem, where the rule index is higher than the size of the list of violations. This will lead to "Index out of Bounds".

This pull request tries to mitigate this, by limiting the access thought the list size and takes an empty list otherwise.