### PR TITLE
added handling and propagation of exceptions in OWLAPIImpl

### DIFF
--- a/architecture-description-parser/src/main/java/org/archcnl/architecturedescriptionparser/CNLTranslator.java
+++ b/architecture-description-parser/src/main/java/org/archcnl/architecturedescriptionparser/CNLTranslator.java
@@ -58,7 +58,8 @@ public class CNLTranslator {
             int index,
             String rulePath,
             String ontologyPath,
-            List<ArchitectureRule> rules) {
+            List<ArchitectureRule> rules)
+            throws IOException {
         LOG.debug("Transforming the rule from CNL to an OWL constraint ...");
         RuleType typeOfParsedRule = generator.transformCNLFile(rulePath, ontologyPath);
 

--- a/org.architecture.cnl.parent/org.architecture.cnl/src/main/java/org/architecture/cnl/CNL2OWLGenerator.java
+++ b/org.architecture.cnl.parent/org.architecture.cnl/src/main/java/org/architecture/cnl/CNL2OWLGenerator.java
@@ -1,6 +1,8 @@
 package org.architecture.cnl;
 
 import com.google.inject.Injector;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -29,8 +31,9 @@ public class CNL2OWLGenerator {
      * @param path The path of the file to transform.
      * @param outputPath The path of the output file.
      * @return The RuleType of the parsed rule or null when something went wrong.
+     * @throws IOException
      */
-    public RuleType transformCNLFile(String path, String outputPath) {
+    public RuleType transformCNLFile(String path, String outputPath) throws IOException {
 
         LOG.trace("transforming CNL file with path: " + path);
 
@@ -61,7 +64,11 @@ public class CNL2OWLGenerator {
         InMemoryFileSystemAccess fsa = new InMemoryFileSystemAccess();
 
         LOG.trace("resource: " + resource);
-        generator.doGenerate(resource, fsa);
+        try {
+            generator.doGenerate(resource, fsa);
+        } catch (UncheckedIOException e) {
+            throw new IOException("Failure while generating", e);
+        }
 
         RuleType ruleType = RuleTypeStorageSingleton.getInstance().retrieveTypeOfRule(id);
 

--- a/org.architecture.cnl.parent/org.architecture.cnl/src/main/java/org/architecture/cnl/generator/ArchcnlGenerator.java
+++ b/org.architecture.cnl.parent/org.architecture.cnl/src/main/java/org/architecture/cnl/generator/ArchcnlGenerator.java
@@ -2,6 +2,8 @@ package org.architecture.cnl.generator;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,7 +54,11 @@ public class ArchcnlGenerator extends AbstractGenerator {
         this.namespace = "http://www.arch-ont.org/ontologies/architecture.owl";
         final String filename = RuleTypeStorageSingleton.getInstance().getOutputFile();
         this.api = APIFactory.get();
-        this.api.createOntology(filename, this.namespace);
+        try {
+            this.api.createOntology(filename, this.namespace);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Error while creating an ontology", e);
+        }
         Iterable<EObject> resourceIterable =
                 IteratorExtensions.toIterable(resource.getAllContents());
         Iterable<Sentence> sentenceIterable = Iterables.filter(resourceIterable, Sentence.class);

--- a/owl-creator/src/main/java/org/archcnl/owlcreator/api/OntologyAPI.java
+++ b/owl-creator/src/main/java/org/archcnl/owlcreator/api/OntologyAPI.java
@@ -1,5 +1,6 @@
 package org.archcnl.owlcreator.api;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLClassExpression;
@@ -19,8 +20,9 @@ public interface OntologyAPI {
      *
      * @param filePath The path to the file in which the ontology will be stored (in XML format).
      * @param iriPath The IRI (international resource modifier) path/prefix of this ontology.
+     * @throws IOException
      */
-    public void createOntology(String filePath, String iriPath);
+    public void createOntology(String filePath, String iriPath) throws IOException;
 
     /**
      * The current ontology cannot be added after calling this method. This method is also closing

--- a/owl-creator/src/main/java/org/archcnl/owlcreator/impl/OWLAPIImpl.java
+++ b/owl-creator/src/main/java/org/archcnl/owlcreator/impl/OWLAPIImpl.java
@@ -1,6 +1,7 @@
 package org.archcnl.owlcreator.impl;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
@@ -42,7 +43,7 @@ public class OWLAPIImpl implements OntologyAPI {
     public OWLAPIImpl() {}
 
     @Override
-    public void createOntology(String filePath, String iriPath) {
+    public void createOntology(String filePath, String iriPath) throws IOException {
         LOG.trace(
                 "creating ontology with filePath \""
                         + filePath
@@ -65,12 +66,10 @@ public class OWLAPIImpl implements OntologyAPI {
             manager.saveOntology(currentOntology, documentIRI2);
         } catch (OWLOntologyCreationException e) {
             LOG.error("Creating an ontology failed.");
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            throw new IOException("Creating an ontology failed", e);
         } catch (OWLOntologyStorageException e) {
             LOG.error("Saving an ontology failed.");
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            throw new IOException("Saving an ontology failed.", e);
         }
     }
 

--- a/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
+++ b/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
@@ -190,9 +190,12 @@ public class CNLToolchain {
         }
 
         createTemporaryDirectory();
-
-        List<ArchitectureRule> rules = parseRuleFile(docPath);
-
+        List<ArchitectureRule> rules;
+        try {
+            rules = parseRuleFile(docPath);
+        } catch (IOException e) {
+            throw new IOException("Rules could not be parsed", e);
+        }
         Model codeModel = buildCodeModel(sourceCodePaths);
 
         combineArchitectureAndCodeModels(rules, codeModel);


### PR DESCRIPTION
I added re-throwing of caught exceptions and added propagation until execute(...) is reached.
In the path to execute there was a section where I could not add throws IOException to a function
since it was an overloaded function from another library. Here I used UncheckedIOExceptions to
pass the exception further up.
Questions:
Is logging fine as it is?
Is the usage of UncheckedIOException a problem?
