### PR TITLE
Feature/archcnl 62/grey out query row

### DIFF
--- a/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
+++ b/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
@@ -71,6 +71,7 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
         subjectTextfield.setEnabled(isEnabled);
         objectTextfield.setEnabled(isEnabled);
         predicateTextfield.setEnabled(isEnabled);
+        minusButton.setEnabled(isEnabled);
         if (isEnabled) {
             pauseButton.getElement().setProperty("title", "Pauses (Disables) this row of queries");
         } else {

--- a/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
+++ b/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
@@ -23,10 +23,10 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
     private PauseButton pauseButton = new PauseButton(new Icon(VaadinIcon.PAUSE));
     private boolean isEnabled = true;
     private boolean isLast = false;
-    private String tooltipMessageDisable =
-            "Pauses (disables) this row of triplets (subject, predicate, and object)";
-    private String tooltipMessageEnable =
-            "Unpauses (activates) this row of triplets (subject, predicate, and object)";
+    private String tooltipMessageEnabled =
+            "Disables this row of subject, predicate, and object";
+    private String tooltipMessageDisabled =
+            "Enables this row of subject, predicate, and object)";
 
     public WhereTextBoxesLayout() {
         addTextField(
@@ -60,7 +60,7 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
                 e -> {
                     pauseRow();
                 });
-        pauseButton.getElement().setProperty("title", tooltipMessageDisable);
+        pauseButton.getElement().setProperty("title", tooltipMessageEnabled);
         add(addButton);
         add(minusButton);
         add(pauseButton);
@@ -73,9 +73,9 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
         predicateTextField.setEnabled(isEnabled);
         minusButton.setEnabled(isEnabled);
         if (isEnabled) {
-            pauseButton.getElement().setProperty("title", tooltipMessageDisable);
+            pauseButton.getElement().setProperty("title", tooltipMessageEnabled);
         } else {
-            pauseButton.getElement().setProperty("title", tooltipMessageEnable);
+            pauseButton.getElement().setProperty("title", tooltipMessageDisabled);
         }
     }
 

--- a/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
+++ b/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
@@ -23,26 +23,30 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
     private PauseButton pauseButton = new PauseButton(new Icon(VaadinIcon.PAUSE));
     private boolean isEnabled = true;
     private boolean isLast = false;
+    private TextField subjectTextfield, objectTextfield, predicateTextfield;
 
     public WhereTextBoxesLayout() {
-        addTextField(
-                "Subject",
-                subjectTextField,
-                e -> {
-                    // TODO do something useful with this
-                });
-        addTextField(
-                "Object",
-                objectTextField,
-                e -> {
-                    // TODO do something useful with this
-                });
-        addTextField(
-                "Predicate",
-                predicateTextField,
-                e -> {
-                    // TODO do something useful with this
-                });
+        subjectTextfield =
+                addTextField(
+                        "Subject",
+                        subjectTextField,
+                        e -> {
+                            // TODO do something useful with this
+                        });
+        objectTextfield =
+                addTextField(
+                        "Object",
+                        objectTextField,
+                        e -> {
+                            // TODO do something useful with this
+                        });
+        predicateTextfield =
+                addTextField(
+                        "Predicate",
+                        predicateTextField,
+                        e -> {
+                            // TODO do something useful with this
+                        });
 
         addButton.addClickListener(
                 e -> {
@@ -54,14 +58,27 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
                 });
         pauseButton.addClickListener(
                 e -> {
-                    isEnabled = !isEnabled;
+                    pauseRow();
                 });
+        pauseButton.getElement().setProperty("title", "Pauses (Disables) this row of queries");
         add(addButton);
         add(minusButton);
         add(pauseButton);
     }
 
-    void addTextField(
+    void pauseRow() {
+        isEnabled = !isEnabled;
+        subjectTextfield.setEnabled(isEnabled);
+        objectTextfield.setEnabled(isEnabled);
+        predicateTextfield.setEnabled(isEnabled);
+        if (isEnabled) {
+            pauseButton.getElement().setProperty("title", "Pauses (Disables) this row of queries");
+        } else {
+            pauseButton.getElement().setProperty("title", "Unpauses this row of queries");
+        }
+    }
+
+    TextField addTextField(
             String placeHolder,
             TextField textField,
             HasValue.ValueChangeListener<
@@ -71,6 +88,7 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
         textField.addValueChangeListener(listener);
         textField.setValueChangeMode(ValueChangeMode.LAZY);
         add(textField);
+        return textField;
     }
 
     public List<String> getObjSubPredString() {

--- a/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
+++ b/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
@@ -23,6 +23,10 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
     private PauseButton pauseButton = new PauseButton(new Icon(VaadinIcon.PAUSE));
     private boolean isEnabled = true;
     private boolean isLast = false;
+    private String tooltipMessageDisable =
+            "Pauses (disables) this row of triplets (subject, predicate, and object)";
+    private String tooltipMessageEnable =
+            "Unpauses (activates) this row of triplets (subject, predicate, and object)";
 
     public WhereTextBoxesLayout() {
         addTextField(
@@ -56,7 +60,7 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
                 e -> {
                     pauseRow();
                 });
-        pauseButton.getElement().setProperty("title", "Pauses (Disables) this row of queries");
+        pauseButton.getElement().setProperty("title", tooltipMessageDisable);
         add(addButton);
         add(minusButton);
         add(pauseButton);
@@ -69,9 +73,9 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
         predicateTextField.setEnabled(isEnabled);
         minusButton.setEnabled(isEnabled);
         if (isEnabled) {
-            pauseButton.getElement().setProperty("title", "Pauses (Disables) this row of queries");
+            pauseButton.getElement().setProperty("title", tooltipMessageDisable);
         } else {
-            pauseButton.getElement().setProperty("title", "Unpauses this row of queries");
+            pauseButton.getElement().setProperty("title", tooltipMessageEnable);
         }
     }
 

--- a/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
+++ b/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
@@ -23,10 +23,8 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
     private PauseButton pauseButton = new PauseButton(new Icon(VaadinIcon.PAUSE));
     private boolean isEnabled = true;
     private boolean isLast = false;
-    private String tooltipMessageEnabled =
-            "Disables this row of subject, predicate, and object";
-    private String tooltipMessageDisabled =
-            "Enables this row of subject, predicate, and object)";
+    private String tooltipMessageEnabled = "Disables this row of subject, predicate, and object";
+    private String tooltipMessageDisabled = "Enables this row of subject, predicate, and object)";
 
     public WhereTextBoxesLayout() {
         addTextField(

--- a/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
+++ b/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
@@ -75,7 +75,7 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
         }
     }
 
-    TextField addTextField(
+    void addTextField(
             String placeHolder,
             TextField textField,
             HasValue.ValueChangeListener<
@@ -85,7 +85,6 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
         textField.addValueChangeListener(listener);
         textField.setValueChangeMode(ValueChangeMode.LAZY);
         add(textField);
-        return textField;
     }
 
     public List<String> getObjSubPredString() {

--- a/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
+++ b/web-ui/src/main/java/org/vaadin/example/queryview/WhereTextBoxesLayout.java
@@ -23,30 +23,26 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
     private PauseButton pauseButton = new PauseButton(new Icon(VaadinIcon.PAUSE));
     private boolean isEnabled = true;
     private boolean isLast = false;
-    private TextField subjectTextfield, objectTextfield, predicateTextfield;
 
     public WhereTextBoxesLayout() {
-        subjectTextfield =
-                addTextField(
-                        "Subject",
-                        subjectTextField,
-                        e -> {
-                            // TODO do something useful with this
-                        });
-        objectTextfield =
-                addTextField(
-                        "Object",
-                        objectTextField,
-                        e -> {
-                            // TODO do something useful with this
-                        });
-        predicateTextfield =
-                addTextField(
-                        "Predicate",
-                        predicateTextField,
-                        e -> {
-                            // TODO do something useful with this
-                        });
+        addTextField(
+                "Subject",
+                subjectTextField,
+                e -> {
+                    // TODO do something useful with this
+                });
+        addTextField(
+                "Object",
+                objectTextField,
+                e -> {
+                    // TODO do something useful with this
+                });
+        addTextField(
+                "Predicate",
+                predicateTextField,
+                e -> {
+                    // TODO do something useful with this
+                });
 
         addButton.addClickListener(
                 e -> {
@@ -68,9 +64,9 @@ public class WhereTextBoxesLayout extends HorizontalLayout {
 
     void pauseRow() {
         isEnabled = !isEnabled;
-        subjectTextfield.setEnabled(isEnabled);
-        objectTextfield.setEnabled(isEnabled);
-        predicateTextfield.setEnabled(isEnabled);
+        subjectTextField.setEnabled(isEnabled);
+        objectTextField.setEnabled(isEnabled);
+        predicateTextField.setEnabled(isEnabled);
         minusButton.setEnabled(isEnabled);
         if (isEnabled) {
             pauseButton.getElement().setProperty("title", "Pauses (Disables) this row of queries");


### PR DESCRIPTION
Reopened PR from @cmkehler as I had to revert the previous merge since it contained format violations.

Pausing a row dow greys out the textfields.
The plus button remains active so that users can add more query rows without having to unpause the first row.
Since every row only needs a delete (minus button), it may be better to have only a single plus button (above or below the rows)
which adds new rows. But that is not subject to this ticket.
I've also added a small tooltip for the pausebutton. This tooltip changes depending on whether the row is active or not.