### PR TITLE
Added missing PrimitiveType float to Famix

### DIFF
--- a/owlify-famix/src/main/resources/ontologies/famix.owl
+++ b/owlify-famix/src/main/resources/ontologies/famix.owl
@@ -747,6 +747,11 @@
         <rdf:type rdf:resource="http://arch-ont.org/ontologies/famix.owl#PrimitiveType"/>
         <hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">double</hasName>
     </owl:NamedIndividual>
+    
+    <owl:NamedIndividual rdf:about="http://arch-ont.org/ontologies/famix.owl#float">
+        <rdf:type rdf:resource="http://arch-ont.org/ontologies/famix.owl#PrimitiveType"/>
+        <hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">float</hasName>
+    </owl:NamedIndividual>
 
     <owl:NamedIndividual rdf:about="http://arch-ont.org/ontologies/famix.owl#char">
         <rdf:type rdf:resource="http://arch-ont.org/ontologies/famix.owl#PrimitiveType"/>


### PR DESCRIPTION
Up to this point, Famix had no concept of the common primitive float. This caused the toolchain to fail when presented with a project that contained a float (for example as an attribute). As should be changed as that makes ArchCNL unusable for the vast majority of projects...