### PR TITLE
Presenter and Contract for InputView added

### DIFF
--- a/web-ui/src/main/java/org/archcnl/ui/input/ConceptAndRelationView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/ConceptAndRelationView.java
@@ -2,7 +2,6 @@ package org.archcnl.ui.input;
 
 import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -17,23 +16,22 @@ public class ConceptAndRelationView extends VerticalLayout implements PropertyCh
 
     private static final long serialVersionUID = 1L;
 
-    private InputView parent;
-    CreateNewLayout createNewConceptLayout;
-    CreateNewLayout createNewRelationLayout;
-    HorizontalLayout bottomBarLayout = new HorizontalLayout();
-    MappingListLayout conceptTreeGrid;
-    MappingListLayout relationTreeGrid;
+    private InputContract.Remote inputRemote;
+    private CreateNewLayout createNewConceptLayout;
+    private CreateNewLayout createNewRelationLayout;
+    private MappingListLayout conceptTreeGrid;
+    private MappingListLayout relationTreeGrid;
 
-    public ConceptAndRelationView(InputView parent, MainPresenter mainPresenter) {
-        this.parent = parent;
-        ButtonClickResponder conceptCreationClickResponder = this::switchToConceptEditorView;
-        ButtonClickResponder relationCreationClickResponder = this::switchToRelationEditorView;
+    public ConceptAndRelationView(InputContract.Remote inputRemote, MainPresenter mainPresenter) {
+        this.inputRemote = inputRemote;
         createNewConceptLayout =
                 new CreateNewLayout(
-                        "Concepts", "Create new concept", conceptCreationClickResponder);
+                        "Concepts", "Create new concept", inputRemote::switchToConceptEditorView);
         createNewRelationLayout =
                 new CreateNewLayout(
-                        "Relations", "Create new relation", relationCreationClickResponder);
+                        "Relations",
+                        "Create new relation",
+                        inputRemote::switchToRelationEditorView);
         RulesConceptsAndRelations.getInstance().getConceptManager().addPropertyChangeListener(this);
         RulesConceptsAndRelations.getInstance()
                 .getRelationManager()
@@ -58,7 +56,7 @@ public class ConceptAndRelationView extends VerticalLayout implements PropertyCh
         if (conceptTreeGrid != null) {
             createNewConceptLayout.remove(conceptTreeGrid);
         }
-        conceptTreeGrid = new MappingListLayout(conceptData, parent);
+        conceptTreeGrid = new MappingListLayout(conceptData, inputRemote);
         createNewConceptLayout.add(conceptTreeGrid);
     }
 
@@ -72,7 +70,7 @@ public class ConceptAndRelationView extends VerticalLayout implements PropertyCh
         if (relationTreeGrid != null) {
             createNewRelationLayout.remove(relationTreeGrid);
         }
-        relationTreeGrid = new MappingListLayout(relationData, parent);
+        relationTreeGrid = new MappingListLayout(relationData, inputRemote);
         createNewRelationLayout.add(relationTreeGrid);
     }
 
@@ -80,13 +78,5 @@ public class ConceptAndRelationView extends VerticalLayout implements PropertyCh
     public void propertyChange(PropertyChangeEvent evt) {
         updateConceptView();
         updateRelationView();
-    }
-
-    public void switchToConceptEditorView() {
-        parent.switchToConceptEditorView();
-    }
-
-    public void switchToRelationEditorView() {
-        parent.switchToRelationEditorView();
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/input/InputContract.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/InputContract.java
@@ -1,0 +1,38 @@
+package org.archcnl.ui.input;
+
+import java.io.Serializable;
+import org.archcnl.domain.input.model.mappings.CustomConcept;
+import org.archcnl.domain.input.model.mappings.CustomRelation;
+import org.archcnl.ui.input.ruleeditor.ArchitectureRulesLayout;
+
+public interface InputContract {
+
+    public interface View extends Serializable {
+
+        public void changeCurrentlyShownView(RulesOrMappingEditorView newView);
+    }
+
+    public interface Presenter extends Serializable {
+
+        public void setView(InputContract.View view);
+
+        public ConceptAndRelationView createConceptAndRelationView();
+
+        public ArchitectureRulesLayout createArchitectureRulesLayout();
+    }
+
+    public interface Remote extends Serializable {
+
+        public void switchToConceptEditorView();
+
+        public void switchToConceptEditorView(CustomConcept concept);
+
+        public void switchToRelationEditorView();
+
+        public void switchToRelationEditorView(CustomRelation relation);
+
+        public void switchToArchitectureRulesView();
+
+        public void switchToNewArchitectureRuleView();
+    }
+}

--- a/web-ui/src/main/java/org/archcnl/ui/input/InputPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/InputPresenter.java
@@ -1,0 +1,81 @@
+package org.archcnl.ui.input;
+
+import org.archcnl.domain.input.model.mappings.CustomConcept;
+import org.archcnl.domain.input.model.mappings.CustomRelation;
+import org.archcnl.ui.input.InputContract.View;
+import org.archcnl.ui.input.mappingeditor.ConceptEditorPresenter;
+import org.archcnl.ui.input.mappingeditor.ConceptEditorView;
+import org.archcnl.ui.input.mappingeditor.MappingEditorView;
+import org.archcnl.ui.input.mappingeditor.RelationEditorPresenter;
+import org.archcnl.ui.input.mappingeditor.RelationEditorView;
+import org.archcnl.ui.input.ruleeditor.ArchitectureRulesLayout;
+import org.archcnl.ui.input.ruleeditor.NewArchitectureRulePresenter;
+import org.archcnl.ui.input.ruleeditor.NewArchitectureRuleView;
+import org.archcnl.ui.main.MainPresenter;
+
+public class InputPresenter implements InputContract.Presenter, InputContract.Remote {
+
+    private static final long serialVersionUID = 7554955330532215929L;
+    private View view;
+    private MainPresenter mainPresenter;
+
+    public InputPresenter(MainPresenter mainPresenter) {
+        this.mainPresenter = mainPresenter;
+    }
+
+    @Override
+    public void setView(View view) {
+        this.view = view;
+    }
+
+    @Override
+    public void switchToConceptEditorView() {
+        ConceptEditorPresenter conceptEditorPresenter = new ConceptEditorPresenter();
+        MappingEditorView mappingEditorView = new ConceptEditorView(conceptEditorPresenter, this);
+        view.changeCurrentlyShownView(mappingEditorView);
+    }
+
+    @Override
+    public void switchToConceptEditorView(CustomConcept concept) {
+        ConceptEditorPresenter conceptEditorPresenter = new ConceptEditorPresenter(concept);
+        MappingEditorView mappingEditorView = new ConceptEditorView(conceptEditorPresenter, this);
+        view.changeCurrentlyShownView(mappingEditorView);
+    }
+
+    @Override
+    public void switchToRelationEditorView() {
+        RelationEditorPresenter relationEditorPresenter = new RelationEditorPresenter();
+        MappingEditorView mappingEditorView = new RelationEditorView(relationEditorPresenter, this);
+        view.changeCurrentlyShownView(mappingEditorView);
+    }
+
+    @Override
+    public void switchToRelationEditorView(CustomRelation relation) {
+        RelationEditorPresenter relationEditorPresenter = new RelationEditorPresenter(relation);
+        MappingEditorView mappingEditorView = new RelationEditorView(relationEditorPresenter, this);
+        view.changeCurrentlyShownView(mappingEditorView);
+    }
+
+    @Override
+    public void switchToArchitectureRulesView() {
+        RulesOrMappingEditorView architectureRulesView = new ArchitectureRulesLayout(this);
+        view.changeCurrentlyShownView(architectureRulesView);
+    }
+
+    @Override
+    public void switchToNewArchitectureRuleView() {
+        NewArchitectureRulePresenter presenter = new NewArchitectureRulePresenter(this);
+        NewArchitectureRuleView newArchitectureRuleView = new NewArchitectureRuleView(presenter);
+        view.changeCurrentlyShownView(newArchitectureRuleView);
+    }
+
+    @Override
+    public ConceptAndRelationView createConceptAndRelationView() {
+        return new ConceptAndRelationView(this, mainPresenter);
+    }
+
+    @Override
+    public ArchitectureRulesLayout createArchitectureRulesLayout() {
+        return new ArchitectureRulesLayout(this);
+    }
+}

--- a/web-ui/src/main/java/org/archcnl/ui/input/InputView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/InputView.java
@@ -2,73 +2,31 @@ package org.archcnl.ui.input;
 
 import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import org.archcnl.domain.input.model.mappings.CustomConcept;
-import org.archcnl.domain.input.model.mappings.CustomRelation;
-import org.archcnl.ui.input.mappingeditor.ConceptEditorPresenter;
-import org.archcnl.ui.input.mappingeditor.ConceptEditorView;
-import org.archcnl.ui.input.mappingeditor.MappingEditorView;
-import org.archcnl.ui.input.mappingeditor.RelationEditorPresenter;
-import org.archcnl.ui.input.mappingeditor.RelationEditorView;
-import org.archcnl.ui.input.ruleeditor.ArchitectureRulesLayout;
-import org.archcnl.ui.input.ruleeditor.NewArchitectureRulePresenter;
-import org.archcnl.ui.input.ruleeditor.NewArchitectureRuleView;
-import org.archcnl.ui.main.MainPresenter;
+import org.archcnl.ui.input.InputContract.Presenter;
 
-public class InputView extends HorizontalLayout {
+public class InputView extends HorizontalLayout implements InputContract.View {
 
     private static final long serialVersionUID = 1L;
     private static final float GOLDEN_RATIO = 61.8f;
 
     private ConceptAndRelationView conceptAndRelationView;
-    private RulesOrMappingEditorView architectureRulesView;
     private RulesOrMappingEditorView currentlyShownView;
+    private Presenter presenter;
 
-    public InputView(MainPresenter mainPresenter) {
-        conceptAndRelationView = new ConceptAndRelationView(this, mainPresenter);
-        architectureRulesView = new ArchitectureRulesLayout(this);
+    public InputView(InputContract.Presenter presenter) {
+        this.presenter = presenter;
+        this.presenter.setView(this);
         setWidth(100, Unit.PERCENTAGE);
         setHeight(100, Unit.PERCENTAGE);
+        conceptAndRelationView = presenter.createConceptAndRelationView();
         conceptAndRelationView.setWidth(100.0f - GOLDEN_RATIO, Unit.PERCENTAGE);
 
-        changeCurrentlyShownView(architectureRulesView);
+        changeCurrentlyShownView(presenter.createArchitectureRulesLayout());
         addAndExpand(currentlyShownView, conceptAndRelationView);
     }
 
-    public void switchToConceptEditorView() {
-        ConceptEditorPresenter conceptEditorPresenter = new ConceptEditorPresenter();
-        MappingEditorView view = new ConceptEditorView(conceptEditorPresenter, this);
-        changeCurrentlyShownView(view);
-    }
-
-    public void switchToConceptEditorView(CustomConcept concept) {
-        ConceptEditorPresenter conceptEditorPresenter = new ConceptEditorPresenter(concept);
-        MappingEditorView view = new ConceptEditorView(conceptEditorPresenter, this);
-        changeCurrentlyShownView(view);
-    }
-
-    public void switchToRelationEditorView() {
-        RelationEditorPresenter relationEditorPresenter = new RelationEditorPresenter();
-        MappingEditorView view = new RelationEditorView(relationEditorPresenter, this);
-        changeCurrentlyShownView(view);
-    }
-
-    public void switchToRelationEditorView(CustomRelation relation) {
-        RelationEditorPresenter relationEditorPresenter = new RelationEditorPresenter(relation);
-        MappingEditorView view = new RelationEditorView(relationEditorPresenter, this);
-        changeCurrentlyShownView(view);
-    }
-
-    public void switchToArchitectureRulesView() {
-        changeCurrentlyShownView(architectureRulesView);
-    }
-
-    public void switchToNewArchitectureRuleView() {
-        NewArchitectureRulePresenter presenter = new NewArchitectureRulePresenter(this);
-        NewArchitectureRuleView view = new NewArchitectureRuleView(presenter);
-        changeCurrentlyShownView(view);
-    }
-
-    private void changeCurrentlyShownView(RulesOrMappingEditorView newView) {
+    @Override
+    public void changeCurrentlyShownView(RulesOrMappingEditorView newView) {
         newView.setWidth(GOLDEN_RATIO, Unit.PERCENTAGE);
         replace(currentlyShownView, newView);
         currentlyShownView = newView;

--- a/web-ui/src/main/java/org/archcnl/ui/input/MappingListEntryLayout.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/MappingListEntryLayout.java
@@ -14,11 +14,11 @@ public class MappingListEntryLayout extends HorizontalLayout {
     private final String DELETE_TEXT = "Delete";
     private Button editButton;
     private Button deleteButton;
-    private InputView inputView;
+    private InputContract.Remote inputRemote;
 
-    public MappingListEntryLayout(MappingListEntry entry, InputView inputView) {
+    public MappingListEntryLayout(MappingListEntry entry, InputContract.Remote inputRemote) {
         this.entry = entry;
-        this.inputView = inputView;
+        this.inputRemote = inputRemote;
 
         Span text = new Span(entry.toString());
         text.setWidth("100%");
@@ -42,10 +42,10 @@ public class MappingListEntryLayout extends HorizontalLayout {
     protected void editButtonPressed() {
         if (entry instanceof ConceptListEntry) {
             ConceptListEntry conceptListEntry = (ConceptListEntry) entry;
-            inputView.switchToConceptEditorView((CustomConcept) conceptListEntry.getContent());
+            inputRemote.switchToConceptEditorView((CustomConcept) conceptListEntry.getContent());
         } else if (entry instanceof RelationListEntry) {
             RelationListEntry relationListEntry = (RelationListEntry) entry;
-            inputView.switchToRelationEditorView((CustomRelation) relationListEntry.getContent());
+            inputRemote.switchToRelationEditorView((CustomRelation) relationListEntry.getContent());
         }
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/input/MappingListLayout.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/MappingListLayout.java
@@ -8,13 +8,13 @@ public class MappingListLayout extends TreeGrid<MappingListEntry> {
 
     private static final long serialVersionUID = 3L;
 
-    public MappingListLayout(List<MappingListEntry> entries, InputView inputView) {
+    public MappingListLayout(List<MappingListEntry> entries, InputContract.Remote inputRemote) {
         super();
         setItems(entries, MappingListEntry::getChildren);
         addComponentHierarchyColumn(
                 entry -> {
                     MappingListEntryLayout entryLayout =
-                            new MappingListEntryLayout(entry, inputView);
+                            new MappingListEntryLayout(entry, inputRemote);
 
                     if (entry.isLeaf()) {
                         DragSource<MappingListEntryLayout> dragSource =

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/ConceptEditorPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/ConceptEditorPresenter.java
@@ -12,7 +12,7 @@ import org.archcnl.domain.input.model.RulesConceptsAndRelations;
 import org.archcnl.domain.input.model.mappings.AndTriplets;
 import org.archcnl.domain.input.model.mappings.ConceptMapping;
 import org.archcnl.domain.input.model.mappings.CustomConcept;
-import org.archcnl.ui.input.InputView;
+import org.archcnl.ui.input.InputContract;
 import org.archcnl.ui.input.mappingeditor.exceptions.MappingAlreadyExistsException;
 import org.archcnl.ui.input.mappingeditor.exceptions.SubjectOrObjectNotDefinedException;
 
@@ -54,7 +54,7 @@ public class ConceptEditorPresenter extends MappingEditorPresenter {
     }
 
     @Override
-    public void doneButtonClicked(InputView parent) {
+    public void doneButtonClicked(InputContract.Remote inputRemote) {
         if (concept.isPresent()) {
             try {
                 ConceptMapping mapping =
@@ -68,7 +68,7 @@ public class ConceptEditorPresenter extends MappingEditorPresenter {
                             .getConceptManager()
                             .addConcept(concept.get());
                 }
-                parent.switchToArchitectureRulesView();
+                inputRemote.switchToArchitectureRulesView();
             } catch (UnrelatedMappingException
                     | UnsupportedObjectTypeInTriplet
                     | RelationDoesNotExistException

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/ConceptEditorView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/ConceptEditorView.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.archcnl.domain.input.exceptions.InvalidVariableNameException;
 import org.archcnl.domain.input.model.mappings.ObjectType;
 import org.archcnl.domain.input.model.mappings.Variable;
-import org.archcnl.ui.input.InputView;
+import org.archcnl.ui.input.InputContract;
 import org.archcnl.ui.input.mappingeditor.MappingEditorContract.View;
 import org.archcnl.ui.input.mappingeditor.exceptions.SubjectOrObjectNotDefinedException;
 import org.archcnl.ui.input.mappingeditor.triplet.SubjectPresenter;
@@ -19,8 +19,9 @@ public class ConceptEditorView extends MappingEditorView {
     private SubjectPresenter subjectPresenter;
     private SubjectView subjectView;
 
-    public ConceptEditorView(MappingEditorContract.Presenter<View> presenter, InputView parent) {
-        super(presenter, parent, "Concept");
+    public ConceptEditorView(
+            MappingEditorContract.Presenter<View> presenter, InputContract.Remote inputRemote) {
+        super(presenter, inputRemote, "Concept");
     }
 
     @Override

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/MappingEditorContract.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/MappingEditorContract.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.archcnl.domain.input.exceptions.InvalidVariableNameException;
 import org.archcnl.domain.input.model.mappings.ObjectType;
 import org.archcnl.domain.input.model.mappings.Variable;
-import org.archcnl.ui.input.InputView;
+import org.archcnl.ui.input.InputContract;
 import org.archcnl.ui.input.mappingeditor.exceptions.SubjectOrObjectNotDefinedException;
 
 public interface MappingEditorContract {
@@ -60,7 +60,7 @@ public interface MappingEditorContract {
 
         public int numberOfAndTriplets();
 
-        public void doneButtonClicked(InputView parent);
+        public void doneButtonClicked(InputContract.Remote inputRemote);
 
         public void lastAndTripletsDeleted();
 

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/MappingEditorView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/MappingEditorView.java
@@ -12,7 +12,7 @@ import com.vaadin.flow.component.textfield.TextField;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.archcnl.domain.input.model.mappings.AndTriplets;
-import org.archcnl.ui.input.InputView;
+import org.archcnl.ui.input.InputContract;
 import org.archcnl.ui.input.RulesOrMappingEditorView;
 import org.archcnl.ui.input.mappingeditor.MappingEditorContract.View;
 import org.archcnl.ui.input.mappingeditor.triplet.VariableListPresenter;
@@ -27,7 +27,9 @@ public abstract class MappingEditorView extends RulesOrMappingEditorView
     protected TextField mappingName;
 
     protected MappingEditorView(
-            MappingEditorContract.Presenter<View> presenter, InputView parent, String mappingType) {
+            MappingEditorContract.Presenter<View> presenter,
+            InputContract.Remote inputRemote,
+            String mappingType) {
         this.presenter = presenter;
         setHeightFull();
         getStyle().set("overflow", "auto");
@@ -42,7 +44,7 @@ public abstract class MappingEditorView extends RulesOrMappingEditorView
         Button closeButton =
                 new Button(
                         new Icon(VaadinIcon.CLOSE),
-                        click -> parent.switchToArchitectureRulesView());
+                        click -> inputRemote.switchToArchitectureRulesView());
         HorizontalLayout titleBar = new HorizontalLayout(title, closeButton);
         titleBar.setWidthFull();
         title.setWidthFull();
@@ -71,8 +73,8 @@ public abstract class MappingEditorView extends RulesOrMappingEditorView
         HorizontalLayout buttonRow = new HorizontalLayout();
         buttonRow.setWidthFull();
         buttonRow.setJustifyContentMode(FlexComponent.JustifyContentMode.END);
-        buttonRow.add(new Button("Done", click -> presenter.doneButtonClicked(parent)));
-        buttonRow.add(new Button("Cancel", click -> parent.switchToArchitectureRulesView()));
+        buttonRow.add(new Button("Done", click -> presenter.doneButtonClicked(inputRemote)));
+        buttonRow.add(new Button("Cancel", click -> inputRemote.switchToArchitectureRulesView()));
         add(buttonRow);
         this.presenter.setView(this);
     }

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/RelationEditorPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/RelationEditorPresenter.java
@@ -11,7 +11,7 @@ import org.archcnl.domain.input.model.RulesConceptsAndRelations;
 import org.archcnl.domain.input.model.mappings.AndTriplets;
 import org.archcnl.domain.input.model.mappings.CustomRelation;
 import org.archcnl.domain.input.model.mappings.RelationMapping;
-import org.archcnl.ui.input.InputView;
+import org.archcnl.ui.input.InputContract;
 import org.archcnl.ui.input.mappingeditor.exceptions.MappingAlreadyExistsException;
 import org.archcnl.ui.input.mappingeditor.exceptions.SubjectOrObjectNotDefinedException;
 
@@ -54,7 +54,7 @@ public class RelationEditorPresenter extends MappingEditorPresenter {
     }
 
     @Override
-    public void doneButtonClicked(InputView parent) {
+    public void doneButtonClicked(InputContract.Remote inputRemote) {
         if (relation.isPresent()) {
             try {
                 RelationMapping mapping =
@@ -71,7 +71,7 @@ public class RelationEditorPresenter extends MappingEditorPresenter {
                             .getRelationManager()
                             .addRelation(relation.get());
                 }
-                parent.switchToArchitectureRulesView();
+                inputRemote.switchToArchitectureRulesView();
             } catch (UnrelatedMappingException
                     | UnsupportedObjectTypeInTriplet
                     | InvalidVariableNameException

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/RelationEditorView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/RelationEditorView.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.archcnl.domain.input.exceptions.InvalidVariableNameException;
 import org.archcnl.domain.input.model.mappings.ObjectType;
 import org.archcnl.domain.input.model.mappings.Variable;
-import org.archcnl.ui.input.InputView;
+import org.archcnl.ui.input.InputContract;
 import org.archcnl.ui.input.mappingeditor.MappingEditorContract.View;
 import org.archcnl.ui.input.mappingeditor.exceptions.SubjectOrObjectNotDefinedException;
 import org.archcnl.ui.input.mappingeditor.triplet.SubjectPresenter;
@@ -21,8 +21,9 @@ public class RelationEditorView extends MappingEditorView {
     private SubjectView subjectView;
     private VariableStringBoolSelectionView objectView;
 
-    public RelationEditorView(MappingEditorContract.Presenter<View> presenter, InputView parent) {
-        super(presenter, parent, "Relation");
+    public RelationEditorView(
+            MappingEditorContract.Presenter<View> presenter, InputContract.Remote inputRemote) {
+        super(presenter, inputRemote, "Relation");
     }
 
     @Override

--- a/web-ui/src/main/java/org/archcnl/ui/input/ruleeditor/ArchitectureRulesLayout.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/ruleeditor/ArchitectureRulesLayout.java
@@ -7,22 +7,22 @@ import java.util.List;
 import org.archcnl.domain.input.model.RulesConceptsAndRelations;
 import org.archcnl.domain.input.model.architecturerules.ArchitectureRule;
 import org.archcnl.ui.input.CreateNewLayout;
-import org.archcnl.ui.input.InputView;
+import org.archcnl.ui.input.InputContract;
 import org.archcnl.ui.input.RulesOrMappingEditorView;
 
 public class ArchitectureRulesLayout extends RulesOrMappingEditorView
         implements PropertyChangeListener {
 
     private static final long serialVersionUID = 1L;
-    private InputView parent;
+    private InputContract.Remote inputRemote;
 
     VerticalLayout rulesLayout = new VerticalLayout();
 
-    public ArchitectureRulesLayout(InputView parent) {
+    public ArchitectureRulesLayout(InputContract.Remote inputRemote) {
         RulesConceptsAndRelations.getInstance()
                 .getArchitectureRuleManager()
                 .addPropertyChangeListener(this);
-        this.parent = parent;
+        this.inputRemote = inputRemote;
         CreateNewLayout createNewRuleLayout =
                 new CreateNewLayout(
                         "Architecture Rules",
@@ -50,7 +50,7 @@ public class ArchitectureRulesLayout extends RulesOrMappingEditorView
     }
 
     public void switchToNewArchitectureRuleView() {
-        parent.switchToNewArchitectureRuleView();
+        inputRemote.switchToNewArchitectureRuleView();
     }
 
     @Override

--- a/web-ui/src/main/java/org/archcnl/ui/input/ruleeditor/NewArchitectureRulePresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/ruleeditor/NewArchitectureRulePresenter.java
@@ -3,16 +3,16 @@ package org.archcnl.ui.input.ruleeditor;
 import org.archcnl.domain.input.exceptions.NoArchitectureRuleException;
 import org.archcnl.domain.input.model.RulesConceptsAndRelations;
 import org.archcnl.domain.input.model.architecturerules.ArchitectureRule;
-import org.archcnl.ui.input.InputView;
+import org.archcnl.ui.input.InputContract;
 import org.archcnl.ui.input.ruleeditor.ArchitectureRulesContract.View;
 
 public class NewArchitectureRulePresenter implements ArchitectureRulesContract.Presenter<View> {
 
     private static final long serialVersionUID = -5047059702637257819L;
-    private InputView parent;
+    private InputContract.Remote inputRemote;
 
-    public NewArchitectureRulePresenter(InputView parent) {
-        this.parent = parent;
+    public NewArchitectureRulePresenter(InputContract.Remote inputRemote) {
+        this.inputRemote = inputRemote;
     }
 
     @Override
@@ -35,6 +35,6 @@ public class NewArchitectureRulePresenter implements ArchitectureRulesContract.P
 
     @Override
     public void returnToRulesView() {
-        parent.switchToArchitectureRulesView();
+        inputRemote.switchToArchitectureRulesView();
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/main/MainPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/main/MainPresenter.java
@@ -6,8 +6,8 @@ import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import org.archcnl.domain.input.ProjectManager;
 import org.archcnl.ui.common.ConfirmNotification;
+import org.archcnl.ui.input.InputPresenter;
 import org.archcnl.ui.input.InputView;
-import org.archcnl.ui.main.MainContract.View;
 import org.archcnl.ui.main.io.OpenProjectDialog;
 import org.archcnl.ui.main.io.SaveProjectDialog;
 import org.archcnl.ui.output.component.QueryView;
@@ -16,18 +16,19 @@ public class MainPresenter
         implements MainContract.Presenter<MainContract.View>, PropertyChangeListener {
 
     private static final long serialVersionUID = 2859025859553864862L;
-    private View view;
+    private MainContract.View view;
     private HorizontalLayout resultView;
     private HorizontalLayout inputView;
 
     public MainPresenter() {
-        inputView = new InputView(this);
+        InputPresenter inputPresenter = new InputPresenter(this);
+        inputView = new InputView(inputPresenter);
         resultView = new QueryView(this);
         ProjectManager.getInstance().addPropertyChangeListener(this);
     }
 
     @Override
-    public void setView(View view) {
+    public void setView(MainContract.View view) {
         this.view = view;
     }
 


### PR DESCRIPTION
Added the missing contracted presenter for `InputView`.
Additionally, I propose a change to the contract pattern:

- A MVP contract now has three nested interfaces:
    - `View`
    - `Presenter`
    - And the new `Remote` interface
- The `View` stays unchanged.
- The `Presenter` class of a `View` now implements the `Presenter` and the `Remote` interfaces.
- The `Presenter` interface is now limited to those functions the view is allowed to call on its `Presenter`.
- The `Remote` is comparable to a true TV remote as it defines the actions third party classes can use to "remote control" the `View`.
- This allows for tighter control of which functions child presenters are allowed to call on the `Presenter` which helps to prevent cyclic function calls.

A sample implementation for this can be seen in the `InputContract`.