### PR TITLE
Basic Rules and Mappings for Web-UI module

### DIFF
--- a/web-ui/architecture-rules.adoc
+++ b/web-ui/architecture-rules.adoc
@@ -2,14 +2,35 @@
 
 == MVP Pattern
 
-[role="mapping"]
-isGuiClass: (?class rdf:type famix:FamixClass) (?class architecture:inheritFromRecursive ?superClass) (?superClass famix:hasName ?name) regex(?name, 'Component') -> (?class rdf:type architecture:GuiClass)
+[role="rule"]
+No ModelClass can use a GuiClass.
+
+[role="rule"]
+No View can use a ModelClass.
+
+[role="rule"]
+Every View must have a Presenter.
+
+[role="rule"]
+Every Presenter must have a View.
+
+[role="rule"]
+Every View must inheritFrom a ContractView.
+
+[role="rule"]
+Every Presenter must inheritFrom a ContractPresenter.
 
 [role="mapping"]
-isView: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*View') -> (?class rdf:type architecture:View)
+isModelClass: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:namespaceContains ?class) (?package famix:hasName ?name) regex(?name, '.*\.domain\..*') -> (?class rdf:type architecture:ModelClass)
 
 [role="mapping"]
-isPresenter: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*Presenter') -> (?class rdf:type architecture:Presenter)
+isGuiClass: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:namespaceContains ?class) (?package famix:hasName ?name) regex(?name, '.*\.ui\..*') -> (?class rdf:type architecture:GuiClass)
+
+[role="mapping"]
+isView: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*View') (?class famix:isInterface 'false'^^xsd:boolean) -> (?class rdf:type architecture:View)
+
+[role="mapping"]
+isPresenter: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*Presenter') (?class famix:isInterface 'false'^^xsd:boolean) -> (?class rdf:type architecture:Presenter)
 
 [role="mapping"]
 isContract: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*Contract') -> (?class rdf:type architecture:Contract)
@@ -19,6 +40,9 @@ isContractView: (?contract rdf:type architecture:Contract) (?contract famix:defi
 
 [role="mapping"]
 isContractPresenter: (?contract rdf:type architecture:Contract) (?contract famix:definesNestedType ?nestedType) (?nestedType famix:hasName ?name) regex(?name, 'Presenter') -> (?nestedType rdf:type architecture:ContractPresenter)
+
+[role="mapping"]
+haveMapping: (?view rdf:type architecture:View) (?presenter rdf:type architecture:Presenter) (?view famix:hasName ?vName) (?presenter famix:hasName ?pName) regex(?vName, '(\\w*)(View|Presenter)', ?vPrefix) regex(?pName, '(\\w*)(View|Presenter)', ?pPrefix) regex(?vPrefix, ?pPrefix) -> (?view architecture:have ?presenter) (?presenter architecture:have ?view)
 
 === General
 
@@ -36,6 +60,6 @@ inheritFromMapping: (?inheritance rdf:type famix:Inheritance) (?inheritance fami
 
 [role="mapping"]
 inheritFromRecursiveMapping: (?subClass architecture:inheritFrom ?superClass) -> (?subClass architecture:inheritFromRecursive ?superClass)
-
+// The recursive part is currently not working
 [role="mapping"]
 inheritFromRecursiveMapping: (?subClass architecture:inheritFromRecursive ?superClass) (?subsubClass architecture:inheritFrom ?subClass) -> (?subsubClass architecture:inheritFromRecursive ?superClass)

--- a/web-ui/architecture-rules.adoc
+++ b/web-ui/architecture-rules.adoc
@@ -1,5 +1,27 @@
 
 
+== MVP Pattern
+
+[role="mapping"]
+isGuiClass: (?class rdf:type famix:FamixClass) (?class architecture:inheritFromRecursive ?superClass) (?superClass famix:hasName ?name) regex(?name, 'Component') -> (?class rdf:type architecture:GuiClass)
+
+[role="mapping"]
+isView: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*View') -> (?class rdf:type architecture:View)
+
+[role="mapping"]
+isPresenter: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*Presenter') -> (?class rdf:type architecture:Presenter)
+
+[role="mapping"]
+isContract: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*Contract') -> (?class rdf:type architecture:Contract)
+
+[role="mapping"]
+isContractView: (?contract rdf:type architecture:Contract) (?contract famix:definesNestedType ?nestedType) (?nestedType famix:hasName ?name) regex(?name, 'View') -> (?nestedType rdf:type architecture:ContractView)
+
+[role="mapping"]
+isContractPresenter: (?contract rdf:type architecture:Contract) (?contract famix:definesNestedType ?nestedType) (?nestedType famix:hasName ?name) regex(?name, 'Presenter') -> (?nestedType rdf:type architecture:ContractPresenter)
+
+=== General
+
 [role="mapping"]
 resideInMapping: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:namespaceContains ?class) -> (?class architecture:residein ?package)
 
@@ -10,10 +32,10 @@ useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClas
 useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClass) (?class famix:imports ?class2) -> (?class architecture:use ?class2)
 
 [role="mapping"]
-isView: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*View') -> (?class rdf:type architecture:View)
+inheritFromMapping: (?inheritance rdf:type famix:Inheritance) (?inheritance famix:hasSuperClass ?superClass) (?inheritance famix:hasSubClass ?subClass) -> (?subClass architecture:inheritFrom ?superClass)
 
 [role="mapping"]
-isPresenter: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*Presenter') -> (?class rdf:type architecture:Presenter)
+inheritFromRecursiveMapping: (?subClass architecture:inheritFrom ?superClass) -> (?subClass architecture:inheritFromRecursive ?superClass)
 
 [role="mapping"]
-isContract: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*Contract') -> (?class rdf:type architecture:Contract)
+inheritFromRecursiveMapping: (?subClass architecture:inheritFromRecursive ?superClass) (?subsubClass architecture:inheritFrom ?subClass) -> (?subsubClass architecture:inheritFromRecursive ?superClass)

--- a/web-ui/architecture-rules.adoc
+++ b/web-ui/architecture-rules.adoc
@@ -57,9 +57,3 @@ useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClas
 
 [role="mapping"]
 inheritFromMapping: (?inheritance rdf:type famix:Inheritance) (?inheritance famix:hasSuperClass ?superClass) (?inheritance famix:hasSubClass ?subClass) -> (?subClass architecture:inheritFrom ?superClass)
-
-[role="mapping"]
-inheritFromRecursiveMapping: (?subClass architecture:inheritFrom ?superClass) -> (?subClass architecture:inheritFromRecursive ?superClass)
-// The recursive part is currently not working
-[role="mapping"]
-inheritFromRecursiveMapping: (?subClass architecture:inheritFromRecursive ?superClass) (?subsubClass architecture:inheritFrom ?subClass) -> (?subsubClass architecture:inheritFromRecursive ?superClass)

--- a/web-ui/architecture-rules.adoc
+++ b/web-ui/architecture-rules.adoc
@@ -1,0 +1,19 @@
+
+
+[role="mapping"]
+resideInMapping: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:namespaceContains ?class) -> (?class architecture:residein ?package)
+
+[role="mapping"]
+useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClass) (?attribute rdf:type famix:Attribute) (?class famix:definesAttribute ?attribute) (?attribute famix:hasDeclaredType ?class2) -> (?class architecture:use ?class2)
+
+[role="mapping"]
+useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClass) (?class famix:imports ?class2) -> (?class architecture:use ?class2)
+
+[role="mapping"]
+isView: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*View') -> (?class rdf:type architecture:View)
+
+[role="mapping"]
+isPresenter: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*Presenter') -> (?class rdf:type architecture:Presenter)
+
+[role="mapping"]
+isContract: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*Contract') -> (?class rdf:type architecture:Contract)

--- a/web-ui/architecture-rules.adoc
+++ b/web-ui/architecture-rules.adoc
@@ -42,7 +42,7 @@ isContractView: (?contract rdf:type architecture:Contract) (?contract famix:defi
 isContractPresenter: (?contract rdf:type architecture:Contract) (?contract famix:definesNestedType ?nestedType) (?nestedType famix:hasName ?name) regex(?name, 'Presenter') -> (?nestedType rdf:type architecture:ContractPresenter)
 
 [role="mapping"]
-haveMapping: (?view rdf:type architecture:View) (?presenter rdf:type architecture:Presenter) (?view famix:hasName ?vName) (?presenter famix:hasName ?pName) regex(?vName, '(\\w*)(View|Presenter)', ?vPrefix) regex(?pName, '(\\w*)(View|Presenter)', ?pPrefix) regex(?vPrefix, ?pPrefix) -> (?view architecture:have ?presenter) (?presenter architecture:have ?view)
+haveMapping: (?view rdf:type architecture:View) (?presenter rdf:type architecture:Presenter) (?view famix:hasName ?vName) (?presenter famix:hasName ?pName) regex(?vName, '(\\w*)View', ?vPrefix) regex(?pName, '(\\w*)Presenter', ?pPrefix) regex(?vPrefix, ?pPrefix) -> (?view architecture:have ?presenter) (?presenter architecture:have ?view)
 
 === General
 


### PR DESCRIPTION
These mappings and rules can be used to check whether the chosen flavor of the MVP pattern is used correctly in the web-ui module.
One additional mapping that would be nice to have but does not seem to work as of now is the following one with its recursive definition:

```
[role="mapping"]
inheritFromRecursiveMapping: (?subClass architecture:inheritFrom ?superClass) -> (?subClass architecture:inheritFromRecursive ?superClass)

[role="mapping"]
inheritFromRecursiveMapping: (?subClass architecture:inheritFromRecursive ?superClass) (?subsubClass architecture:inheritFrom ?subClass) -> (?subsubClass architecture:inheritFromRecursive ?superClass)
```

This mapping could be used to make rules for all classes that inherit from Vaadin's Component class.