### PR TITLE
Concept/Relation List now update with every change

### DIFF
--- a/web-ui/src/main/java/org/archcnl/domain/input/model/mappings/Concept.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/model/mappings/Concept.java
@@ -44,6 +44,7 @@ public abstract class Concept extends ObjectType {
                 .getConceptManager()
                 .doesConceptExist(new CustomConcept(newName))) {
             this.name = newName;
+            RulesConceptsAndRelations.getInstance().getConceptManager().conceptHasBeenUpdated(this);
         } else {
             throw new ConceptAlreadyExistsException(newName);
         }
@@ -55,5 +56,6 @@ public abstract class Concept extends ObjectType {
 
     public void setDescription(String description) {
         this.description = description;
+        RulesConceptsAndRelations.getInstance().getConceptManager().conceptHasBeenUpdated(this);
     }
 }

--- a/web-ui/src/main/java/org/archcnl/domain/input/model/mappings/ConceptManager.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/model/mappings/ConceptManager.java
@@ -29,6 +29,10 @@ public class ConceptManager {
         }
     }
 
+    public void conceptHasBeenUpdated(Concept concept) {
+        propertyChangeSupport.firePropertyChange("conceptUpdated", null, concept);
+    }
+
     public void addOrAppend(CustomConcept concept) throws UnrelatedMappingException {
         try {
             if (!doesConceptExist(concept)) {

--- a/web-ui/src/main/java/org/archcnl/domain/input/model/mappings/Relation.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/model/mappings/Relation.java
@@ -121,6 +121,9 @@ public abstract class Relation {
                 .getRelationManager()
                 .doesRelationExist(new CustomRelation(newName, new LinkedList<>()))) {
             this.name = newName;
+            RulesConceptsAndRelations.getInstance()
+                    .getRelationManager()
+                    .relationHasBeenUpdated(this);
         } else {
             throw new RelationAlreadyExistsException(newName);
         }
@@ -132,5 +135,6 @@ public abstract class Relation {
 
     public void setDescription(String description) {
         this.description = description;
+        RulesConceptsAndRelations.getInstance().getRelationManager().relationHasBeenUpdated(this);
     }
 }

--- a/web-ui/src/main/java/org/archcnl/domain/input/model/mappings/RelationManager.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/model/mappings/RelationManager.java
@@ -34,6 +34,10 @@ public class RelationManager {
         }
     }
 
+    public void relationHasBeenUpdated(Relation relation) {
+        propertyChangeSupport.firePropertyChange("relationUpdated", null, relation);
+    }
+
     public void addOrAppend(CustomRelation relation) throws UnrelatedMappingException {
         try {
             if (!doesRelationExist(relation)) {

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/ConceptEditorPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/ConceptEditorPresenter.java
@@ -111,4 +111,9 @@ public class ConceptEditorPresenter extends MappingEditorPresenter {
                 .getConceptManager()
                 .doesConceptExist(concept);
     }
+
+    @Override
+    public void descriptionHasChanged(String value) {
+        concept.get().setDescription(value);
+    }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/MappingEditorContract.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/MappingEditorContract.java
@@ -73,5 +73,7 @@ public interface MappingEditorContract {
         public void showFirstAndTripletsView();
 
         public void selectedObjectTypeHasChanged();
+
+        public void descriptionHasChanged(String value);
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/MappingEditorView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/MappingEditorView.java
@@ -64,6 +64,10 @@ public abstract class MappingEditorView extends RulesOrMappingEditorView
         description = new TextField("Description");
         description.setWidthFull();
         description.setPlaceholder("Describtion of the Concept/Relation");
+        description.addValueChangeListener(
+                event -> {
+                    presenter.descriptionHasChanged(event.getValue());
+                });
         add(description);
 
         // TODO: add used in functionality

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/RelationEditorPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/RelationEditorPresenter.java
@@ -63,6 +63,7 @@ public class RelationEditorPresenter extends MappingEditorPresenter {
     protected void initInfoFieldAndThenTriplet() {
         if (relation.isPresent()) {
             view.updateNameField(relation.get().getName());
+            view.updateDescription(relation.get().getDescription());
             view.updateNameFieldInThenTriplet(relation.get().getName());
             relation.get()
                     .getMapping()
@@ -119,5 +120,10 @@ public class RelationEditorPresenter extends MappingEditorPresenter {
         return RulesConceptsAndRelations.getInstance()
                 .getRelationManager()
                 .doesRelationExist(relation);
+    }
+
+    @Override
+    public void descriptionHasChanged(String value) {
+        relation.get().setDescription(value);
     }
 }


### PR DESCRIPTION
Previously the lists would only update after creating a new concept or a new relation. 