### PR TITLE
Placeholder text of description TextField changed

### DIFF
--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/MappingEditorView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/MappingEditorView.java
@@ -63,7 +63,7 @@ public abstract class MappingEditorView extends RulesOrMappingEditorView
 
         description = new TextField("Description");
         description.setWidthFull();
-        description.setPlaceholder("Describtion of the Concept/Relation");
+        description.setPlaceholder("What does this " + mappingType + " represent?");
         description.addValueChangeListener(
                 event -> {
                     presenter.descriptionHasChanged(event.getValue());


### PR DESCRIPTION
- Previously there was a spelling mistake in that text
- The inclusion of"Concept" and "Relation" in the text is not necessary as the constructor parameter `mappingType` holds just the right string for that purpose
- I thought the "What does this Concept represent?" placeholder text might be a better incentive for the user to enter a fitting description