### PR TITLE
Update log4j to recommended version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<mwe2Version>2.11.3</mwe2Version>
 		<xtextVersion>2.22.0</xtextVersion>
-		<log4jVersion>2.14.0</log4jVersion>
+		<log4jVersion>2.15.0</log4jVersion>
 		<stanfordnlpVersion>3.9.1</stanfordnlpVersion>
 		<commonsioVersion>2.6</commonsioVersion>
 		<apachejenaVersion>3.3.0</apachejenaVersion>


### PR DESCRIPTION
The currently used version of log4j contained a critical vulnerability (see https://www.kaspersky.com/blog/log4shell-critical-vulnerability-in-apache-log4j/43124/). This PR updates log4j to the recommended version.