### PR TITLE
Feature/arch cnl 129/description exporter importer

### DIFF
--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
@@ -36,14 +36,20 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
 
     private static final Logger LOG = LogManager.getLogger(ArchRulesFromAdocReader.class);
 
+    private static final Pattern DESCRIPTION_TEXT_PATTERN =
+            Pattern.compile(
+                    "(w+(?=(\r\n?|\n)))");
+    private static final Pattern DESCRIPTION_PATTERN =
+            Pattern.compile(
+                    "(?<=\\[role=\"description\"\\](\r\n?|\n))" + DESCRIPTION_TEXT_PATTERN);
     private static final Pattern RULE_PATTERN =
-            Pattern.compile("(?<=\\[role=\"rule\"\\](\r\n?|\n)).+\\.");
+            Pattern.compile("(" + DESCRIPTION_PATTERN + ")+" + "(?<=\\[role=\"rule\"\\](\r\n?|\n)).+\\.");
     private static final Pattern CONCEPT_MAPPING_PATTERN =
             Pattern.compile(
-                    "(?<=\\[role=\\\"mapping\\\"\\](\\r\\n?|\\n))is\\w+\\: (.+ )?\\-\\> \\(.+ rdf:type .+\\)");
+            		"(" + DESCRIPTION_PATTERN + ")+" + "(?<=\\[role=\\\"mapping\\\"\\](\\r\\n?|\\n))is\\w+\\: (.+ )?\\-\\> \\(.+ rdf:type .+\\)");
     private static final Pattern RELATION_MAPPING_PATTERN =
             Pattern.compile(
-                    "(?<=\\[role=\\\"mapping\\\"\\](\\r\\n?|\\n))\\w+Mapping\\: (.+ )?\\-\\> \\(.+\\)");
+            		"(" + DESCRIPTION_PATTERN + ")+" + "(?<=\\[role=\\\"mapping\\\"\\](\\r\\n?|\\n))\\w+Mapping\\: (.+ )?\\-\\> \\(.+\\)");
     private static final Pattern NORMAL_TRIPLET_PATTERN =
             Pattern.compile(
                     "\\(\\?\\w+ \\w+:\\w+ (\\?\\w+|\\w+:\\w+|'.*'|'(false|true)'\\^\\^xsd\\:boolean)\\)");

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
@@ -44,15 +44,15 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
     private static final Pattern DESCRIPTION_TEXT_PATTERN =
             Pattern.compile("(?<=\\[role=\"description\"\\](\r\n?|\n))[\\w\\. ]+(?=(\r\n?|\n))");
     private static final Pattern DESCRIPTION_PATTERN =
-            Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)(" + CONCEPT_MAPPING_NAME + "|" + RELATION_MAPPING_NAME + ")[\\w\\. ]+(\r\n?|\n)");
+            Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)((is\\w+:)|(\\w+Mapping:))[\\w\\. ]+(\r\n?|\n)");
     private static final Pattern CONCEPT_DESCRIPTION_PATTERN =
-            Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)" + CONCEPT_MAPPING_NAME + "[\\w\\. ]+(\r\n?|\n)");
+            Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)(is\\w+:)[\\w\\. ]+(\r\n?|\n)");
     private static final Pattern CONCEPT_DESCRIPTION_CONTENT =
-            Pattern.compile("(?<=\\[role=\"description\"\\](\r\n?|\n)" + CONCEPT_MAPPING_NAME + ")[\\w\\. ]+((?=\r\n?|\n))");
-    private static final Pattern RELATION_DESCRIPTION_CONTENT =
-            Pattern.compile("(?<=\\[role=\"description\"\\](\r\n?|\n)" + CONCEPT_MAPPING_NAME + ")[\\w\\. ]+((?=\r\n?|\n))");
+            Pattern.compile("(?<=\\[role=\"description\"\\](\r\n?|\n)(is\\w+:))[\\w\\. ]+((?=\r\n?|\n))");
     private static final Pattern RELATION_DESCRIPTION_PATTERN =
-            Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)" + RELATION_MAPPING_NAME + "[\\w\\. ]+(\r\n?|\n)");
+            Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)(.+Mapping:)[\\w\\. ]+(\r\n?|\n)");
+    private static final Pattern RELATION_DESCRIPTION_CONTENT =
+            Pattern.compile("(?<=\\[role=\"description\"\\](\r\n?|\n)(.+Mapping:))[\\w\\. ]+((?=\r\n?|\n))");
     private static final Pattern RULE_PATTERN =
             Pattern.compile("(" + DESCRIPTION_PATTERN + ")?\\[role=\"rule\"\\](\r\n?|\n).+\\.");
     private static final Pattern RULE_CONTENT_PATTERN =
@@ -100,11 +100,14 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                         String name =
                                 AdocIoUtils.getFirstMatch(
                                         CONCEPT_MAPPING_NAME, conceptDescription);
+                        System.out.println("ConceptMappingName: " + name);
                         String description = 
                                 AdocIoUtils.getFirstMatch(
                                         CONCEPT_DESCRIPTION_CONTENT, conceptDescription);
+                        System.out.println("Description: " + description);
                         conceptDescriptions.put(name, description);
                     } catch (NoMatchFoundException e) {
+                    	System.out.println("No name or description found, " + e);
                         LOG.warn(e.getMessage());
                     }
                 });
@@ -116,9 +119,12 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                         String name =
                                 AdocIoUtils.getFirstMatch(
                                         RELATION_MAPPING_NAME, relationDescription);
+                        System.out.println("RelationMappingName: " + name);
                         String description = 
                                 AdocIoUtils.getFirstMatch(
                                         RELATION_DESCRIPTION_CONTENT, relationDescription);
+                        System.out.println("RelationMappingContent: " + name);
+                        System.out.println("Description: " + description);
                         relationDescriptions.put(name, description);
                     } catch (NoMatchFoundException e) {
                         LOG.warn(e.getMessage());
@@ -170,6 +176,7 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                         String description = "";
                         if(relationDescriptions.containsKey(name)) {
                         	description = relationDescriptions.get(name);
+                        	System.out.println("Adding description to: " + name);
                         }
                         CustomRelation relation =
                                 new CustomRelation(name, description, new LinkedList<>());

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
@@ -37,10 +37,12 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
 
     private static final Logger LOG = LogManager.getLogger(ArchRulesFromAdocReader.class);
 
+    private static final Pattern CONCEPT_MAPPING_NAME = Pattern.compile("(?<=is)\\w+(?=:)");
+    private static final Pattern RELATION_MAPPING_NAME = Pattern.compile(".+(?=Mapping:)");
     private static final Pattern DESCRIPTION_TEXT_PATTERN =
             Pattern.compile("(?<=\\[role=\"description\"\\](\r\n?|\n))[\\w\\. ]+(?=(\r\n?|\n))");
     private static final Pattern DESCRIPTION_PATTERN =
-            Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)[\\w\\. ]+(\r\n?|\n)");
+            Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)(" + CONCEPT_MAPPING_NAME + "|" + RELATION_MAPPING_NAME + ")[\\w\\. ]+(\r\n?|\n)");
     private static final Pattern RULE_PATTERN =
             Pattern.compile("(" + DESCRIPTION_PATTERN + ")?\\[role=\"rule\"\\](\r\n?|\n).+\\.");
     private static final Pattern RULE_CONTENT_PATTERN =
@@ -70,8 +72,6 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
             Pattern.compile(NORMAL_TRIPLET_PATTERN + "|" + SPECIAL_TRIPLET_PATTERN);
     private static final Pattern WHEN_PATTERN = Pattern.compile(".+(?=\\-\\>)");
     private static final Pattern THEN_PATTERN = Pattern.compile("(?<=\\-\\>).+");
-    private static final Pattern CONCEPT_MAPPING_NAME = Pattern.compile("(?<=is)\\w+(?=:)");
-    private static final Pattern RELATION_MAPPING_NAME = Pattern.compile(".+(?=Mapping:)");
 
     @Override
     public void readArchitectureRules(
@@ -84,6 +84,7 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                 .forEach(
                         potentialRule -> {
                             try {
+                            	//TODO: actually add description to rule once they have them
                                 String description = "";
                                 Matcher matcher = DESCRIPTION_TEXT_PATTERN.matcher(potentialRule);
                                 if (matcher.find()) {

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
@@ -43,11 +43,13 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
     private static final Pattern CONCEPT_DESCRIPTION_PATTERN =
             Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)(is\\w+:)[\\w\\. ]+(\r\n?|\n)");
     private static final Pattern CONCEPT_DESCRIPTION_CONTENT =
-            Pattern.compile("(?<=\\[role=\"description\"\\](\r\n?|\n)(is\\w+:))[\\w\\. ]+((?=\r\n?|\n))");
+            Pattern.compile(
+                    "(?<=\\[role=\"description\"\\](\r\n?|\n)(is\\w+:))[\\w\\. ]+((?=\r\n?|\n))");
     private static final Pattern RELATION_DESCRIPTION_PATTERN =
             Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)(.+Mapping:)[\\w\\. ]+(\r\n?|\n)");
     private static final Pattern RELATION_DESCRIPTION_CONTENT =
-            Pattern.compile("(?<=\\[role=\"description\"\\](\r\n?|\n)(.+Mapping:))[\\w\\. ]+((?=\r\n?|\n))");
+            Pattern.compile(
+                    "(?<=\\[role=\"description\"\\](\r\n?|\n)(.+Mapping:))[\\w\\. ]+((?=\r\n?|\n))");
     private static final Pattern RULE_CONTENT_PATTERN =
             Pattern.compile("(?<=\\[role=\"rule\"\\](\r\n?|\n)).+\\.");
     private static final Pattern CONCEPT_MAPPING_PATTERN =
@@ -71,43 +73,41 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
             File file, RulesConceptsAndRelations rulesConceptsAndRelations) throws IOException {
 
         String fileContent = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
-        Map<String, String> conceptDescriptions =
-        	    new HashMap<String, String>();
-        Map<String, String> relationDescriptions =
-        	    new HashMap<String, String>();
+        Map<String, String> conceptDescriptions = new HashMap<String, String>();
+        Map<String, String> relationDescriptions = new HashMap<String, String>();
 
         AdocIoUtils.getAllMatches(CONCEPT_DESCRIPTION_PATTERN, fileContent).stream()
-        .forEach(
-                conceptDescription -> {
-                    try {
-                        String name =
-                                AdocIoUtils.getFirstMatch(
-                                        CONCEPT_MAPPING_NAME, conceptDescription);
-                        String description = 
-                                AdocIoUtils.getFirstMatch(
-                                        CONCEPT_DESCRIPTION_CONTENT, conceptDescription);
-                        conceptDescriptions.put(name, description);
-                    } catch (NoMatchFoundException e) {
-                        LOG.warn(e.getMessage());
-                    }
-                });
-        
+                .forEach(
+                        conceptDescription -> {
+                            try {
+                                String name =
+                                        AdocIoUtils.getFirstMatch(
+                                                CONCEPT_MAPPING_NAME, conceptDescription);
+                                String description =
+                                        AdocIoUtils.getFirstMatch(
+                                                CONCEPT_DESCRIPTION_CONTENT, conceptDescription);
+                                conceptDescriptions.put(name, description);
+                            } catch (NoMatchFoundException e) {
+                                LOG.warn(e.getMessage());
+                            }
+                        });
+
         AdocIoUtils.getAllMatches(RELATION_DESCRIPTION_PATTERN, fileContent).stream()
-        .forEach(
-                relationDescription -> {
-                    try {
-                        String name =
-                                AdocIoUtils.getFirstMatch(
-                                        RELATION_MAPPING_NAME, relationDescription);
-                        String description = 
-                                AdocIoUtils.getFirstMatch(
-                                        RELATION_DESCRIPTION_CONTENT, relationDescription);
-                        relationDescriptions.put(name, description);
-                    } catch (NoMatchFoundException e) {
-                        LOG.warn(e.getMessage());
-                    }
-                });
-        
+                .forEach(
+                        relationDescription -> {
+                            try {
+                                String name =
+                                        AdocIoUtils.getFirstMatch(
+                                                RELATION_MAPPING_NAME, relationDescription);
+                                String description =
+                                        AdocIoUtils.getFirstMatch(
+                                                RELATION_DESCRIPTION_CONTENT, relationDescription);
+                                relationDescriptions.put(name, description);
+                            } catch (NoMatchFoundException e) {
+                                LOG.warn(e.getMessage());
+                            }
+                        });
+
         // Extract and add architecture rules
         AdocIoUtils.getAllMatches(RULE_CONTENT_PATTERN, fileContent).stream()
                 .forEach(
@@ -115,59 +115,57 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                             try {
                                 rulesConceptsAndRelations
                                         .getArchitectureRuleManager()
-                                        .addArchitectureRule(
-                                                parseArchitectureRule(potentialRule));
+                                        .addArchitectureRule(parseArchitectureRule(potentialRule));
                             } catch (NoArchitectureRuleException e) {
                                 LOG.warn(e.getMessage());
                             }
                         });
 
         AdocIoUtils.getAllMatches(CONCEPT_MAPPING_PATTERN, fileContent).stream()
-        .forEach(
-                potentialConceptMapping -> {
-                    try {
-                        String name =
-                                AdocIoUtils.getFirstMatch(
-                                        CONCEPT_MAPPING_NAME, potentialConceptMapping);
-                        String description = "";
-                        if(conceptDescriptions.containsKey(name)) {
-                        	description = conceptDescriptions.get(name);
-                        }
-                        CustomConcept concept = new CustomConcept(name, description);
-                        concept.setMapping(parseMapping(potentialConceptMapping, concept));
-                        rulesConceptsAndRelations.getConceptManager().addOrAppend(concept);
-                    } catch (UnrelatedMappingException
-                            | NoMappingException
-                            | NoMatchFoundException e) {
-                        LOG.warn(e.getMessage());
-                    }
-                });
+                .forEach(
+                        potentialConceptMapping -> {
+                            try {
+                                String name =
+                                        AdocIoUtils.getFirstMatch(
+                                                CONCEPT_MAPPING_NAME, potentialConceptMapping);
+                                String description = "";
+                                if (conceptDescriptions.containsKey(name)) {
+                                    description = conceptDescriptions.get(name);
+                                }
+                                CustomConcept concept = new CustomConcept(name, description);
+                                concept.setMapping(parseMapping(potentialConceptMapping, concept));
+                                rulesConceptsAndRelations.getConceptManager().addOrAppend(concept);
+                            } catch (UnrelatedMappingException
+                                    | NoMappingException
+                                    | NoMatchFoundException e) {
+                                LOG.warn(e.getMessage());
+                            }
+                        });
 
         AdocIoUtils.getAllMatches(RELATION_MAPPING_PATTERN, fileContent).stream()
-        .forEach(
-                potentialRelationMapping -> {
-                    try {
-                        String name =
-                                AdocIoUtils.getFirstMatch(
-                                        RELATION_MAPPING_NAME, potentialRelationMapping);
-                        String description = "";
-                        if(relationDescriptions.containsKey(name)) {
-                        	description = relationDescriptions.get(name);
-                        }
-                        CustomRelation relation =
-                                new CustomRelation(name, description, new LinkedList<>());
-                        relation.setMapping(
-                                parseMapping(potentialRelationMapping, relation));
-                        rulesConceptsAndRelations
-                                .getRelationManager()
-                                .addOrAppend(relation);
-                    } catch (UnrelatedMappingException
-                            | NoMappingException
-                            | NoMatchFoundException e) {
-                        LOG.warn(e.getMessage());
-                    }
-                });
-
+                .forEach(
+                        potentialRelationMapping -> {
+                            try {
+                                String name =
+                                        AdocIoUtils.getFirstMatch(
+                                                RELATION_MAPPING_NAME, potentialRelationMapping);
+                                String description = "";
+                                if (relationDescriptions.containsKey(name)) {
+                                    description = relationDescriptions.get(name);
+                                }
+                                CustomRelation relation =
+                                        new CustomRelation(name, description, new LinkedList<>());
+                                relation.setMapping(
+                                        parseMapping(potentialRelationMapping, relation));
+                                rulesConceptsAndRelations
+                                        .getRelationManager()
+                                        .addOrAppend(relation);
+                            } catch (UnrelatedMappingException
+                                    | NoMappingException
+                                    | NoMatchFoundException e) {
+                                LOG.warn(e.getMessage());
+                            }
+                        });
     }
 
     private ConceptMapping parseMapping(String potentialMapping, CustomConcept thisConcept)
@@ -293,12 +291,12 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
     public static Pattern getRelationMappingPattern() {
         return RELATION_MAPPING_PATTERN;
     }
-    
+
     @VisibleForTesting
     public static Pattern getConceptDescriptionPattern() {
         return CONCEPT_DESCRIPTION_PATTERN;
     }
-    
+
     @VisibleForTesting
     public static Pattern getRelationDescriptionPattern() {
         return RELATION_DESCRIPTION_PATTERN;

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
@@ -38,25 +38,29 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
     private static final Logger LOG = LogManager.getLogger(ArchRulesFromAdocReader.class);
 
     private static final Pattern DESCRIPTION_TEXT_PATTERN =
-            Pattern.compile(
-            		"(?<=\\[role=\"description\"\\](\r\n?|\n))[\\w\\. ]+(?=(\r\n?|\n))");
+            Pattern.compile("(?<=\\[role=\"description\"\\](\r\n?|\n))[\\w\\. ]+(?=(\r\n?|\n))");
     private static final Pattern DESCRIPTION_PATTERN =
-            Pattern.compile(
-                    "\\[role=\"description\"\\](\r\n?|\n)[\\w\\. ]+(\r\n?|\n)");
+            Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)[\\w\\. ]+(\r\n?|\n)");
     private static final Pattern RULE_PATTERN =
             Pattern.compile("(" + DESCRIPTION_PATTERN + ")?\\[role=\"rule\"\\](\r\n?|\n).+\\.");
     private static final Pattern RULE_CONTENT_PATTERN =
             Pattern.compile("(?<=\\[role=\"rule\"\\](\r\n?|\n)).+\\.");
     private static final Pattern CONCEPT_PATTERN =
             Pattern.compile(
-            		"(" + DESCRIPTION_PATTERN + ")?\\[role=\"mapping\"\\](\r\n?|\n)is\\w+\\: (.+ )?\\-\\> \\(.+ rdf:type .+\\)");
+                    "("
+                            + DESCRIPTION_PATTERN
+                            + ")?\\[role=\"mapping\"\\](\r\n?|\n)is\\w+\\: (.+ )?\\-\\> \\(.+ rdf:type .+\\)");
     private static final Pattern CONCEPT_CONTENT_PATTERN =
-            Pattern.compile("(?<=\\[role=\"mapping\"\\](\r\n?|\n))is\\w+\\: (.+ )?\\-\\> \\(.+ rdf:type .+\\)");
+            Pattern.compile(
+                    "(?<=\\[role=\"mapping\"\\](\r\n?|\n))is\\w+\\: (.+ )?\\-\\> \\(.+ rdf:type .+\\)");
     private static final Pattern RELATION_PATTERN =
             Pattern.compile(
-            		"(" + DESCRIPTION_PATTERN + ")?\\[role=\"mapping\"\\](\r\n?|\n)\\w+Mapping\\: (.+ )?\\-\\> \\(.+\\)");
+                    "("
+                            + DESCRIPTION_PATTERN
+                            + ")?\\[role=\"mapping\"\\](\r\n?|\n)\\w+Mapping\\: (.+ )?\\-\\> \\(.+\\)");
     private static final Pattern RELATION_CONTENT_PATTERN =
-            Pattern.compile("(?<=\\[role=\"mapping\"\\](\r\n?|\n))\\w+Mapping\\: (.+ )?\\-\\> \\(.+\\)");
+            Pattern.compile(
+                    "(?<=\\[role=\"mapping\"\\](\r\n?|\n))\\w+Mapping\\: (.+ )?\\-\\> \\(.+\\)");
     private static final Pattern NORMAL_TRIPLET_PATTERN =
             Pattern.compile(
                     "\\(\\?\\w+ \\w+:\\w+ (\\?\\w+|\\w+:\\w+|'.*'|'(false|true)'\\^\\^xsd\\:boolean)\\)");
@@ -72,8 +76,8 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
     @Override
     public void readArchitectureRules(
             File file, RulesConceptsAndRelations rulesConceptsAndRelations) throws IOException {
-    	
-    	System.out.println("readArchitectureRules called");
+
+        System.out.println("readArchitectureRules called");
 
         String fileContent = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
 
@@ -81,20 +85,20 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
         AdocIoUtils.getAllMatches(RULE_PATTERN, fileContent).stream()
                 .forEach(
                         potentialRule -> {
-                        	try {
-                        	String description = "";
-                            Matcher matcher = DESCRIPTION_TEXT_PATTERN.matcher(potentialRule);
-                            if(matcher.find()) {
-                            	description = matcher.group();
-                            }
+                            try {
+                                String description = "";
+                                Matcher matcher = DESCRIPTION_TEXT_PATTERN.matcher(potentialRule);
+                                if (matcher.find()) {
+                                    description = matcher.group();
+                                }
                                 String potentialRuleContent =
                                         AdocIoUtils.getFirstMatch(
                                                 RULE_CONTENT_PATTERN, potentialRule);
                                 rulesConceptsAndRelations
                                         .getArchitectureRuleManager()
-                                        .addArchitectureRule(parseArchitectureRule(potentialRuleContent));
-                            } catch (NoArchitectureRuleException
-                            		| NoMatchFoundException e) {
+                                        .addArchitectureRule(
+                                                parseArchitectureRule(potentialRuleContent));
+                            } catch (NoArchitectureRuleException | NoMatchFoundException e) {
                                 LOG.warn(e.getMessage());
                             }
                         });
@@ -103,12 +107,15 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                 .forEach(
                         potentialConceptMapping -> {
                             try {
-                            	String description = "";
-                                Matcher matcher = DESCRIPTION_TEXT_PATTERN.matcher(potentialConceptMapping);
-                                if(matcher.find()) {
-                                	description = matcher.group();
+                                String description = "";
+                                Matcher matcher =
+                                        DESCRIPTION_TEXT_PATTERN.matcher(potentialConceptMapping);
+                                if (matcher.find()) {
+                                    description = matcher.group();
                                 }
-                                String potentialRuleContent = AdocIoUtils.getFirstMatch(CONCEPT_CONTENT_PATTERN, potentialConceptMapping);
+                                String potentialRuleContent =
+                                        AdocIoUtils.getFirstMatch(
+                                                CONCEPT_CONTENT_PATTERN, potentialConceptMapping);
                                 String name =
                                         AdocIoUtils.getFirstMatch(
                                                 CONCEPT_MAPPING_NAME, potentialRuleContent);
@@ -126,12 +133,15 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                 .forEach(
                         potentialRelationMapping -> {
                             try {
-                            	String description = "";
-                                Matcher matcher = DESCRIPTION_TEXT_PATTERN.matcher(potentialRelationMapping);
-                                if(matcher.find()) {
-                                	description = matcher.group();
+                                String description = "";
+                                Matcher matcher =
+                                        DESCRIPTION_TEXT_PATTERN.matcher(potentialRelationMapping);
+                                if (matcher.find()) {
+                                    description = matcher.group();
                                 }
-                                String potentialRelationContent = AdocIoUtils.getFirstMatch(RELATION_CONTENT_PATTERN, potentialRelationMapping);
+                                String potentialRelationContent =
+                                        AdocIoUtils.getFirstMatch(
+                                                RELATION_CONTENT_PATTERN, potentialRelationMapping);
                                 String name =
                                         AdocIoUtils.getFirstMatch(
                                                 RELATION_MAPPING_NAME, potentialRelationContent);

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
@@ -77,8 +77,6 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
     public void readArchitectureRules(
             File file, RulesConceptsAndRelations rulesConceptsAndRelations) throws IOException {
 
-        System.out.println("readArchitectureRules called");
-
         String fileContent = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
 
         // Extract and add architecture rules

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
@@ -82,16 +82,11 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                 .forEach(
                         potentialRule -> {
                         	try {
-                        	System.out.println("Rule Found: " + potentialRule);
                         	String description = "";
                             Matcher matcher = DESCRIPTION_TEXT_PATTERN.matcher(potentialRule);
                             if(matcher.find()) {
                             	description = matcher.group();
-                            	System.out.println("Description found: " + description);
-                            	//potentialRule.replaceAll("\\[role=\"description\"\\](\r\n?|\n)\\w+(\r\n?|\n)", "");
-                            	System.out.println("Rule after removal: " + potentialRule);
                             }
-                            // TODO: Add the description to the rule once rules have descriptions
                                 String potentialRuleContent =
                                         AdocIoUtils.getFirstMatch(
                                                 RULE_CONTENT_PATTERN, potentialRule);
@@ -108,14 +103,10 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                 .forEach(
                         potentialConceptMapping -> {
                             try {
-                            	System.out.println("Found Concept: " + potentialConceptMapping);
                             	String description = "";
                                 Matcher matcher = DESCRIPTION_TEXT_PATTERN.matcher(potentialConceptMapping);
                                 if(matcher.find()) {
                                 	description = matcher.group();
-                                	//System.out.println("Description found: " + description);
-                                	//potentialConceptMapping.replaceAll(DESCRIPTION_PATTERN.pattern(), "");
-                                	//System.out.println("Rule after removal: " + potentialConceptMapping);
                                 }
                                 String potentialRuleContent = AdocIoUtils.getFirstMatch(CONCEPT_CONTENT_PATTERN, potentialConceptMapping);
                                 String name =
@@ -135,12 +126,10 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                 .forEach(
                         potentialRelationMapping -> {
                             try {
-                            	System.out.println("Found Mapping: " + potentialRelationMapping);
                             	String description = "";
                                 Matcher matcher = DESCRIPTION_TEXT_PATTERN.matcher(potentialRelationMapping);
                                 if(matcher.find()) {
                                 	description = matcher.group();
-                                	//potentialRelationMapping.replaceAll(DESCRIPTION_PATTERN.pattern(), "");
                                 }
                                 String potentialRelationContent = AdocIoUtils.getFirstMatch(RELATION_CONTENT_PATTERN, potentialRelationMapping);
                                 String name =

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
@@ -39,10 +39,10 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
 
     private static final Pattern DESCRIPTION_TEXT_PATTERN =
             Pattern.compile(
-            		"(?<=\\[role=\"description\"\\](\r\n?|\n))\\w+(?=(\r\n?|\n))");
+            		"(?<=\\[role=\"description\"\\](\r\n?|\n))[\\w\\. ]+(?=(\r\n?|\n))");
     private static final Pattern DESCRIPTION_PATTERN =
             Pattern.compile(
-                    "\\[role=\"description\"\\](\r\n?|\n)\\w+(\r\n?|\n)");
+                    "\\[role=\"description\"\\](\r\n?|\n)[\\w\\. ]+(\r\n?|\n)");
     private static final Pattern RULE_PATTERN =
             Pattern.compile("(" + DESCRIPTION_PATTERN + ")?\\[role=\"rule\"\\](\r\n?|\n).+\\.");
     private static final Pattern RULE_CONTENT_PATTERN =
@@ -92,12 +92,12 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                             	System.out.println("Rule after removal: " + potentialRule);
                             }
                             // TODO: Add the description to the rule once rules have descriptions
-                                String potentialRulePart =
+                                String potentialRuleContent =
                                         AdocIoUtils.getFirstMatch(
                                                 RULE_CONTENT_PATTERN, potentialRule);
                                 rulesConceptsAndRelations
                                         .getArchitectureRuleManager()
-                                        .addArchitectureRule(parseArchitectureRule(potentialRulePart));
+                                        .addArchitectureRule(parseArchitectureRule(potentialRuleContent));
                             } catch (NoArchitectureRuleException
                             		| NoMatchFoundException e) {
                                 LOG.warn(e.getMessage());
@@ -113,9 +113,9 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                                 Matcher matcher = DESCRIPTION_TEXT_PATTERN.matcher(potentialConceptMapping);
                                 if(matcher.find()) {
                                 	description = matcher.group();
-                                	System.out.println("Description found: " + description);
+                                	//System.out.println("Description found: " + description);
                                 	//potentialConceptMapping.replaceAll(DESCRIPTION_PATTERN.pattern(), "");
-                                	System.out.println("Rule after removal: " + potentialConceptMapping);
+                                	//System.out.println("Rule after removal: " + potentialConceptMapping);
                                 }
                                 String potentialRuleContent = AdocIoUtils.getFirstMatch(CONCEPT_CONTENT_PATTERN, potentialConceptMapping);
                                 String name =

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesFromAdocReader.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
@@ -41,10 +40,6 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
 
     private static final Pattern CONCEPT_MAPPING_NAME = Pattern.compile("(?<=is)\\w+(?=:)");
     private static final Pattern RELATION_MAPPING_NAME = Pattern.compile(".+(?=Mapping:)");
-    private static final Pattern DESCRIPTION_TEXT_PATTERN =
-            Pattern.compile("(?<=\\[role=\"description\"\\](\r\n?|\n))[\\w\\. ]+(?=(\r\n?|\n))");
-    private static final Pattern DESCRIPTION_PATTERN =
-            Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)((is\\w+:)|(\\w+Mapping:))[\\w\\. ]+(\r\n?|\n)");
     private static final Pattern CONCEPT_DESCRIPTION_PATTERN =
             Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)(is\\w+:)[\\w\\. ]+(\r\n?|\n)");
     private static final Pattern CONCEPT_DESCRIPTION_CONTENT =
@@ -53,24 +48,12 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
             Pattern.compile("\\[role=\"description\"\\](\r\n?|\n)(.+Mapping:)[\\w\\. ]+(\r\n?|\n)");
     private static final Pattern RELATION_DESCRIPTION_CONTENT =
             Pattern.compile("(?<=\\[role=\"description\"\\](\r\n?|\n)(.+Mapping:))[\\w\\. ]+((?=\r\n?|\n))");
-    private static final Pattern RULE_PATTERN =
-            Pattern.compile("(" + DESCRIPTION_PATTERN + ")?\\[role=\"rule\"\\](\r\n?|\n).+\\.");
     private static final Pattern RULE_CONTENT_PATTERN =
             Pattern.compile("(?<=\\[role=\"rule\"\\](\r\n?|\n)).+\\.");
-    private static final Pattern CONCEPT_PATTERN =
-            Pattern.compile(
-                    "("
-                            + DESCRIPTION_PATTERN
-                            + ")?\\[role=\"mapping\"\\](\r\n?|\n)is\\w+\\: (.+ )?\\-\\> \\(.+ rdf:type .+\\)");
-    private static final Pattern CONCEPT_CONTENT_PATTERN =
+    private static final Pattern CONCEPT_MAPPING_PATTERN =
             Pattern.compile(
                     "(?<=\\[role=\"mapping\"\\](\r\n?|\n))is\\w+\\: (.+ )?\\-\\> \\(.+ rdf:type .+\\)");
-    private static final Pattern RELATION_PATTERN =
-            Pattern.compile(
-                    "("
-                            + DESCRIPTION_PATTERN
-                            + ")?\\[role=\"mapping\"\\](\r\n?|\n)\\w+Mapping\\: (.+ )?\\-\\> \\(.+\\)");
-    private static final Pattern RELATION_CONTENT_PATTERN =
+    private static final Pattern RELATION_MAPPING_PATTERN =
             Pattern.compile(
                     "(?<=\\[role=\"mapping\"\\](\r\n?|\n))\\w+Mapping\\: (.+ )?\\-\\> \\(.+\\)");
     private static final Pattern NORMAL_TRIPLET_PATTERN =
@@ -100,14 +83,11 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                         String name =
                                 AdocIoUtils.getFirstMatch(
                                         CONCEPT_MAPPING_NAME, conceptDescription);
-                        System.out.println("ConceptMappingName: " + name);
                         String description = 
                                 AdocIoUtils.getFirstMatch(
                                         CONCEPT_DESCRIPTION_CONTENT, conceptDescription);
-                        System.out.println("Description: " + description);
                         conceptDescriptions.put(name, description);
                     } catch (NoMatchFoundException e) {
-                    	System.out.println("No name or description found, " + e);
                         LOG.warn(e.getMessage());
                     }
                 });
@@ -119,12 +99,9 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                         String name =
                                 AdocIoUtils.getFirstMatch(
                                         RELATION_MAPPING_NAME, relationDescription);
-                        System.out.println("RelationMappingName: " + name);
                         String description = 
                                 AdocIoUtils.getFirstMatch(
                                         RELATION_DESCRIPTION_CONTENT, relationDescription);
-                        System.out.println("RelationMappingContent: " + name);
-                        System.out.println("Description: " + description);
                         relationDescriptions.put(name, description);
                     } catch (NoMatchFoundException e) {
                         LOG.warn(e.getMessage());
@@ -145,7 +122,7 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                             }
                         });
 
-        AdocIoUtils.getAllMatches(CONCEPT_CONTENT_PATTERN, fileContent).stream()
+        AdocIoUtils.getAllMatches(CONCEPT_MAPPING_PATTERN, fileContent).stream()
         .forEach(
                 potentialConceptMapping -> {
                     try {
@@ -166,7 +143,7 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                     }
                 });
 
-        AdocIoUtils.getAllMatches(RELATION_CONTENT_PATTERN, fileContent).stream()
+        AdocIoUtils.getAllMatches(RELATION_MAPPING_PATTERN, fileContent).stream()
         .forEach(
                 potentialRelationMapping -> {
                     try {
@@ -176,7 +153,6 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
                         String description = "";
                         if(relationDescriptions.containsKey(name)) {
                         	description = relationDescriptions.get(name);
-                        	System.out.println("Adding description to: " + name);
                         }
                         CustomRelation relation =
                                 new CustomRelation(name, description, new LinkedList<>());
@@ -310,16 +286,21 @@ public class ArchRulesFromAdocReader implements ArchRulesImporter {
 
     @VisibleForTesting
     public static Pattern getConceptMappingPattern() {
-        return CONCEPT_CONTENT_PATTERN;
+        return CONCEPT_MAPPING_PATTERN;
     }
 
     @VisibleForTesting
     public static Pattern getRelationMappingPattern() {
-        return RELATION_CONTENT_PATTERN;
+        return RELATION_MAPPING_PATTERN;
     }
     
     @VisibleForTesting
-    public static Pattern getDescriptionPattern() {
-        return DESCRIPTION_PATTERN;
+    public static Pattern getConceptDescriptionPattern() {
+        return CONCEPT_DESCRIPTION_PATTERN;
+    }
+    
+    @VisibleForTesting
+    public static Pattern getRelationDescriptionPattern() {
+        return RELATION_DESCRIPTION_PATTERN;
     }
 }

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
@@ -31,9 +31,7 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
         String relationsString = constructRelationString(customRelations);
 
         FileUtils.writeStringToFile(
-                file,
-                rulesString + conceptsString + relationsString,
-                StandardCharsets.UTF_8);
+                file, rulesString + conceptsString + relationsString, StandardCharsets.UTF_8);
     }
 
     private String constructArchRuleString(List<ArchitectureRule> rules) {
@@ -47,19 +45,19 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
         }
         return builder.toString();
     }
-    
+
     private String constructConceptString(List<CustomConcept> concepts) {
         StringBuilder builder = new StringBuilder();
         concepts.removeIf(concept -> concept.getMapping().isEmpty());
         for (CustomConcept concept : concepts) {
-        	Mapping mapping = concept.getMapping().get();
+            Mapping mapping = concept.getMapping().get();
             for (String oneMapping : mapping.toStringRepresentation()) {
-            	if(!concept.getDescription().isEmpty()) {
-            		builder.append("[role=\"description\"]");
-            		builder.append("\n");
-            		builder.append(concept.getDescription());
-            		builder.append("\n");        		
-            	}
+                if (!concept.getDescription().isEmpty()) {
+                    builder.append("[role=\"description\"]");
+                    builder.append("\n");
+                    builder.append(concept.getDescription());
+                    builder.append("\n");
+                }
                 builder.append("[role=\"mapping\"]");
                 builder.append("\n");
                 builder.append(oneMapping);
@@ -68,19 +66,19 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
         }
         return builder.toString();
     }
-    
+
     private String constructRelationString(List<CustomRelation> relations) {
         StringBuilder builder = new StringBuilder();
         relations.removeIf(relation -> relation.getMapping().isEmpty());
         for (CustomRelation relation : relations) {
-        	Mapping mapping = relation.getMapping().get();
+            Mapping mapping = relation.getMapping().get();
             for (String oneMapping : mapping.toStringRepresentation()) {
-            	if(!relation.getDescription().isEmpty()) {
-            		builder.append("[role=\"description\"]");
-            		builder.append("\n");
-            		builder.append(relation.getDescription());
-            		builder.append("\n");        		
-            	}
+                if (!relation.getDescription().isEmpty()) {
+                    builder.append("[role=\"description\"]");
+                    builder.append("\n");
+                    builder.append(relation.getDescription());
+                    builder.append("\n");
+                }
                 builder.append("[role=\"mapping\"]");
                 builder.append("\n");
                 builder.append(oneMapping);

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
@@ -51,15 +51,15 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
         concepts.removeIf(concept -> concept.getMapping().isEmpty());
         for (CustomConcept concept : concepts) {
             Mapping mapping = concept.getMapping().get();
+            if (!concept.getDescription().isEmpty()) {
+                builder.append("[role=\"description\"]");
+                builder.append("\n");
+                builder.append(mapping.getMappingNameRepresentation());
+                builder.append(": ");
+                builder.append(concept.getDescription());
+                builder.append("\n");
+            }
             for (String oneMapping : mapping.toStringRepresentation()) {
-                if (!concept.getDescription().isEmpty()) {
-                    builder.append("[role=\"description\"]");
-                    builder.append("\n");
-                    builder.append(mapping.getMappingNameRepresentation());
-                    builder.append(": ");
-                    builder.append(concept.getDescription());
-                    builder.append("\n");
-                }
                 builder.append("[role=\"mapping\"]");
                 builder.append("\n");
                 builder.append(oneMapping);
@@ -74,15 +74,15 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
         relations.removeIf(relation -> relation.getMapping().isEmpty());
         for (CustomRelation relation : relations) {
             Mapping mapping = relation.getMapping().get();
+            if (!relation.getDescription().isEmpty()) {
+            	builder.append("[role=\"description\"]");
+            	builder.append("\n");
+            	builder.append(mapping.getMappingNameRepresentation());
+            	builder.append(": ");
+            	builder.append(relation.getDescription());
+            	builder.append("\n");
+            }
             for (String oneMapping : mapping.toStringRepresentation()) {
-                if (!relation.getDescription().isEmpty()) {
-                    builder.append("[role=\"description\"]");
-                    builder.append("\n");
-                    builder.append(mapping.getMappingNameRepresentation());
-                    builder.append(": ");
-                    builder.append(relation.getDescription());
-                    builder.append("\n");
-                }
                 builder.append("[role=\"mapping\"]");
                 builder.append("\n");
                 builder.append(oneMapping);

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
@@ -3,7 +3,6 @@ package org.archcnl.domain.input.io;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.LinkedList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.archcnl.domain.common.CustomConcept;
@@ -25,27 +24,21 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
 
         List<CustomConcept> customConcepts =
                 rulesConceptsAndRelations.getConceptManager().getCustomConcepts();
-        List<Mapping> conceptMappings = new LinkedList<>();
-        customConcepts.forEach(
-                concept -> concept.getMapping().ifPresent(mapping -> conceptMappings.add(mapping)));
-        String conceptMappingsString = constructConceptString(customConcepts);
+        String conceptsString = constructConceptString(customConcepts);
 
         List<CustomRelation> customRelations =
                 rulesConceptsAndRelations.getRelationManager().getCustomRelations();
-        List<Mapping> relationMappings = new LinkedList<>();
-        customRelations.forEach(
-                relation ->
-                        relation.getMapping().ifPresent(mapping -> relationMappings.add(mapping)));
-        String relationMappingsString = constructRelationString(customRelations);
+        String relationsString = constructRelationString(customRelations);
 
         FileUtils.writeStringToFile(
                 file,
-                rulesString + conceptMappingsString + relationMappingsString,
+                rulesString + conceptsString + relationsString,
                 StandardCharsets.UTF_8);
     }
 
     private String constructArchRuleString(List<ArchitectureRule> rules) {
         StringBuilder builder = new StringBuilder();
+        // TODO: Add description once rules have them
         for (ArchitectureRule rule : rules) {
             builder.append("[role=\"rule\"]");
             builder.append("\n");
@@ -61,10 +54,12 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
         for (CustomConcept concept : concepts) {
         	Mapping mapping = concept.getMapping().get();
             for (String oneMapping : mapping.toStringRepresentation()) {
-            	builder.append("[role=\"description\"]");
-                builder.append("\n");
-                builder.append(concept.getDescription());
-                builder.append("\n");
+            	if(!concept.getDescription().isEmpty()) {
+            		builder.append("[role=\"description\"]");
+            		builder.append("\n");
+            		builder.append(concept.getDescription());
+            		builder.append("\n");        		
+            	}
                 builder.append("[role=\"mapping\"]");
                 builder.append("\n");
                 builder.append(oneMapping);
@@ -80,11 +75,15 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
         for (CustomRelation relation : relations) {
         	Mapping mapping = relation.getMapping().get();
             for (String oneMapping : mapping.toStringRepresentation()) {
+            	if(!relation.getDescription().isEmpty()) {
+            		builder.append("[role=\"description\"]");
+            		builder.append("\n");
+            		builder.append(relation.getDescription());
+            		builder.append("\n");        		
+            	}
                 builder.append("[role=\"mapping\"]");
                 builder.append("\n");
                 builder.append(oneMapping);
-                builder.append("\n");
-                builder.append(relation.getDescription());
                 builder.append("\n\n");
             }
         }

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
@@ -55,6 +55,8 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
                 if (!concept.getDescription().isEmpty()) {
                     builder.append("[role=\"description\"]");
                     builder.append("\n");
+                    builder.append(mapping.getMappingNameRepresentation());
+                    builder.append(": ");
                     builder.append(concept.getDescription());
                     builder.append("\n");
                 }
@@ -76,6 +78,8 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
                 if (!relation.getDescription().isEmpty()) {
                     builder.append("[role=\"description\"]");
                     builder.append("\n");
+                    builder.append(mapping.getMappingNameRepresentation());
+                    builder.append(": ");
                     builder.append(relation.getDescription());
                     builder.append("\n");
                 }

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
@@ -75,12 +75,12 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
         for (CustomRelation relation : relations) {
             Mapping mapping = relation.getMapping().get();
             if (!relation.getDescription().isEmpty()) {
-            	builder.append("[role=\"description\"]");
-            	builder.append("\n");
-            	builder.append(mapping.getMappingNameRepresentation());
-            	builder.append(": ");
-            	builder.append(relation.getDescription());
-            	builder.append("\n");
+                builder.append("[role=\"description\"]");
+                builder.append("\n");
+                builder.append(mapping.getMappingNameRepresentation());
+                builder.append(": ");
+                builder.append(relation.getDescription());
+                builder.append("\n");
             }
             for (String oneMapping : mapping.toStringRepresentation()) {
                 builder.append("[role=\"mapping\"]");

--- a/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/io/ArchRulesToAdocWriter.java
@@ -28,7 +28,7 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
         List<Mapping> conceptMappings = new LinkedList<>();
         customConcepts.forEach(
                 concept -> concept.getMapping().ifPresent(mapping -> conceptMappings.add(mapping)));
-        String conceptMappingsString = constructMappingString(conceptMappings);
+        String conceptMappingsString = constructConceptString(customConcepts);
 
         List<CustomRelation> customRelations =
                 rulesConceptsAndRelations.getRelationManager().getCustomRelations();
@@ -36,7 +36,7 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
         customRelations.forEach(
                 relation ->
                         relation.getMapping().ifPresent(mapping -> relationMappings.add(mapping)));
-        String relationMappingsString = constructMappingString(relationMappings);
+        String relationMappingsString = constructRelationString(customRelations);
 
         FileUtils.writeStringToFile(
                 file,
@@ -54,14 +54,37 @@ public class ArchRulesToAdocWriter implements ArchRulesExporter {
         }
         return builder.toString();
     }
-
-    private String constructMappingString(List<Mapping> mappings) {
+    
+    private String constructConceptString(List<CustomConcept> concepts) {
         StringBuilder builder = new StringBuilder();
-        for (Mapping mapping : mappings) {
+        concepts.removeIf(concept -> concept.getMapping().isEmpty());
+        for (CustomConcept concept : concepts) {
+        	Mapping mapping = concept.getMapping().get();
+            for (String oneMapping : mapping.toStringRepresentation()) {
+            	builder.append("[role=\"description\"]");
+                builder.append("\n");
+                builder.append(concept.getDescription());
+                builder.append("\n");
+                builder.append("[role=\"mapping\"]");
+                builder.append("\n");
+                builder.append(oneMapping);
+                builder.append("\n\n");
+            }
+        }
+        return builder.toString();
+    }
+    
+    private String constructRelationString(List<CustomRelation> relations) {
+        StringBuilder builder = new StringBuilder();
+        relations.removeIf(relation -> relation.getMapping().isEmpty());
+        for (CustomRelation relation : relations) {
+        	Mapping mapping = relation.getMapping().get();
             for (String oneMapping : mapping.toStringRepresentation()) {
                 builder.append("[role=\"mapping\"]");
                 builder.append("\n");
                 builder.append(oneMapping);
+                builder.append("\n");
+                builder.append(relation.getDescription());
                 builder.append("\n\n");
             }
         }

--- a/web-ui/src/test/java/org/archcnl/domain/TestUtils.java
+++ b/web-ui/src/test/java/org/archcnl/domain/TestUtils.java
@@ -202,7 +202,7 @@ public class TestUtils {
         useWhenTriplets.add(new AndTriplets(triplets));
         useWhenTriplets.add(new AndTriplets(triplets2));
 
-        CustomConcept aggregate = new CustomConcept("Aggregate", "");
+        CustomConcept aggregate = new CustomConcept("Aggregate", "Every class whose name ends with Aggregate is an Aggregate.");
         ConceptMapping aggregateMapping =
                 new ConceptMapping(classVariable, aggregateWhenTriplets, aggregate);
         aggregate.setMapping(aggregateMapping);
@@ -225,7 +225,7 @@ public class TestUtils {
                         resideInWhenTriplets);
         resideIn.setMapping(resideInMapping);
 
-        CustomRelation use = new CustomRelation("use", "", new LinkedList<>());
+        CustomRelation use = new CustomRelation("use", "A class uses another class if it has a field of it or if it imports it.", new LinkedList<>());
         RelationMapping useMapping =
                 new RelationMapping(
                         TripletFactory.createTriplet(classVariable, use, class2Variable),

--- a/web-ui/src/test/java/org/archcnl/domain/TestUtils.java
+++ b/web-ui/src/test/java/org/archcnl/domain/TestUtils.java
@@ -41,7 +41,8 @@ public class TestUtils {
         Matcher matcher = regex.matcher(expected);
         while (matcher.find()) {
             String match = matcher.group();
-            if (!actual.contains(match)) {
+            String replaced = match.replaceAll("\r\n?", "\n");  
+            if (!actual.contains(replaced)) {
                 return false;
             }
         }

--- a/web-ui/src/test/java/org/archcnl/domain/TestUtils.java
+++ b/web-ui/src/test/java/org/archcnl/domain/TestUtils.java
@@ -41,7 +41,7 @@ public class TestUtils {
         Matcher matcher = regex.matcher(expected);
         while (matcher.find()) {
             String match = matcher.group();
-            String replaced = match.replaceAll("\r\n?", "\n");  
+            String replaced = match.replaceAll("\r\n?", "\n");
             if (!actual.contains(replaced)) {
                 return false;
             }
@@ -202,7 +202,9 @@ public class TestUtils {
         useWhenTriplets.add(new AndTriplets(triplets));
         useWhenTriplets.add(new AndTriplets(triplets2));
 
-        CustomConcept aggregate = new CustomConcept("Aggregate", "Every class whose name ends with Aggregate is an Aggregate.");
+        CustomConcept aggregate =
+                new CustomConcept(
+                        "Aggregate", "Every class whose name ends with Aggregate is an Aggregate.");
         ConceptMapping aggregateMapping =
                 new ConceptMapping(classVariable, aggregateWhenTriplets, aggregate);
         aggregate.setMapping(aggregateMapping);
@@ -225,7 +227,11 @@ public class TestUtils {
                         resideInWhenTriplets);
         resideIn.setMapping(resideInMapping);
 
-        CustomRelation use = new CustomRelation("use", "A class uses another class if it has a field of it or if it imports it.", new LinkedList<>());
+        CustomRelation use =
+                new CustomRelation(
+                        "use",
+                        "A class uses another class if it has a field of it or if it imports it.",
+                        new LinkedList<>());
         RelationMapping useMapping =
                 new RelationMapping(
                         TripletFactory.createTriplet(classVariable, use, class2Variable),

--- a/web-ui/src/test/java/org/archcnl/domain/input/io/ArchRuleToAdocWriterTest.java
+++ b/web-ui/src/test/java/org/archcnl/domain/input/io/ArchRuleToAdocWriterTest.java
@@ -56,14 +56,14 @@ class ArchRuleToAdocWriterTest {
                         ArchRulesFromAdocReader.getRelationMappingPattern(), actualContent));
         assertEquals(
                 TestUtils.numberOfMatches(
-                        ArchRulesFromAdocReader.getDescriptionPattern(), expectedContent),
+                        ArchRulesFromAdocReader.getConceptDescriptionPattern(), expectedContent),
                 TestUtils.numberOfMatches(
-                        ArchRulesFromAdocReader.getDescriptionPattern(), actualContent));
-
-        System.out.println("Matches in expected: " + TestUtils.numberOfMatches(
-                ArchRulesFromAdocReader.getDescriptionPattern(), expectedContent));
-        System.out.println("Matches in actual: " + TestUtils.numberOfMatches(
-                ArchRulesFromAdocReader.getDescriptionPattern(), actualContent));
+                        ArchRulesFromAdocReader.getConceptDescriptionPattern(), actualContent));
+        assertEquals(
+                TestUtils.numberOfMatches(
+                        ArchRulesFromAdocReader.getRelationDescriptionPattern(), expectedContent),
+                TestUtils.numberOfMatches(
+                        ArchRulesFromAdocReader.getRelationDescriptionPattern(), actualContent));
 
         assertTrue(
                 TestUtils.doAllMatchesExistInSecondString(
@@ -80,7 +80,12 @@ class ArchRuleToAdocWriterTest {
                         actualContent));
         assertTrue(
                 TestUtils.doAllMatchesExistInSecondString(
-                        ArchRulesFromAdocReader.getDescriptionPattern(),
+                        ArchRulesFromAdocReader.getConceptDescriptionPattern(),
+                        expectedContent,
+                        actualContent));
+        assertTrue(
+                TestUtils.doAllMatchesExistInSecondString(
+                        ArchRulesFromAdocReader.getRelationDescriptionPattern(),
                         expectedContent,
                         actualContent));
     }

--- a/web-ui/src/test/java/org/archcnl/domain/input/io/ArchRuleToAdocWriterTest.java
+++ b/web-ui/src/test/java/org/archcnl/domain/input/io/ArchRuleToAdocWriterTest.java
@@ -54,6 +54,16 @@ class ArchRuleToAdocWriterTest {
                         ArchRulesFromAdocReader.getRelationMappingPattern(), expectedContent),
                 TestUtils.numberOfMatches(
                         ArchRulesFromAdocReader.getRelationMappingPattern(), actualContent));
+        assertEquals(
+                TestUtils.numberOfMatches(
+                        ArchRulesFromAdocReader.getDescriptionPattern(), expectedContent),
+                TestUtils.numberOfMatches(
+                        ArchRulesFromAdocReader.getDescriptionPattern(), actualContent));
+
+        System.out.println("Matches in expected: " + TestUtils.numberOfMatches(
+                ArchRulesFromAdocReader.getDescriptionPattern(), expectedContent));
+        System.out.println("Matches in actual: " + TestUtils.numberOfMatches(
+                ArchRulesFromAdocReader.getDescriptionPattern(), actualContent));
 
         assertTrue(
                 TestUtils.doAllMatchesExistInSecondString(
@@ -66,6 +76,11 @@ class ArchRuleToAdocWriterTest {
         assertTrue(
                 TestUtils.doAllMatchesExistInSecondString(
                         ArchRulesFromAdocReader.getRelationMappingPattern(),
+                        expectedContent,
+                        actualContent));
+        assertTrue(
+                TestUtils.doAllMatchesExistInSecondString(
+                        ArchRulesFromAdocReader.getDescriptionPattern(),
                         expectedContent,
                         actualContent));
     }

--- a/web-ui/src/test/java/org/archcnl/domain/input/io/ArchRulesFromAdocReaderTest.java
+++ b/web-ui/src/test/java/org/archcnl/domain/input/io/ArchRulesFromAdocReaderTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-
 import org.apache.commons.io.FileUtils;
 import org.archcnl.domain.TestUtils;
 import org.archcnl.domain.common.Concept;
@@ -83,18 +82,33 @@ class ArchRulesFromAdocReaderTest {
             assertTrue(expectedModel.getRelationManager().getInputRelations().contains(relation));
         }
     }
-    
+
     @Test
     void givenRulesAndMappingsInAdocFormat_whenMatchingPatterns_thenMatchesAreFound()
-    throws IOException {
-    	// given, when
+            throws IOException {
+        // given, when
         final File ruleFile = new File("src/test/resources/ReaderParsingTest.adoc");
         String rulesFileString = FileUtils.readFileToString(ruleFile, StandardCharsets.UTF_8);
         // then
-    	assertEquals(2, TestUtils.numberOfMatches(ArchRulesFromAdocReader.getRulePattern(), rulesFileString));
-    	assertEquals(1, TestUtils.numberOfMatches(ArchRulesFromAdocReader.getConceptDescriptionPattern(), rulesFileString));
-    	assertEquals(1, TestUtils.numberOfMatches(ArchRulesFromAdocReader.getRelationDescriptionPattern(), rulesFileString));
-    	assertEquals(5, TestUtils.numberOfMatches(ArchRulesFromAdocReader.getRelationMappingPattern(), rulesFileString));
-    	assertEquals(3, TestUtils.numberOfMatches(ArchRulesFromAdocReader.getConceptMappingPattern(), rulesFileString));
+        assertEquals(
+                2,
+                TestUtils.numberOfMatches(
+                        ArchRulesFromAdocReader.getRulePattern(), rulesFileString));
+        assertEquals(
+                1,
+                TestUtils.numberOfMatches(
+                        ArchRulesFromAdocReader.getConceptDescriptionPattern(), rulesFileString));
+        assertEquals(
+                1,
+                TestUtils.numberOfMatches(
+                        ArchRulesFromAdocReader.getRelationDescriptionPattern(), rulesFileString));
+        assertEquals(
+                5,
+                TestUtils.numberOfMatches(
+                        ArchRulesFromAdocReader.getRelationMappingPattern(), rulesFileString));
+        assertEquals(
+                3,
+                TestUtils.numberOfMatches(
+                        ArchRulesFromAdocReader.getConceptMappingPattern(), rulesFileString));
     }
 }

--- a/web-ui/src/test/java/org/archcnl/domain/input/io/ArchRulesFromAdocReaderTest.java
+++ b/web-ui/src/test/java/org/archcnl/domain/input/io/ArchRulesFromAdocReaderTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
 import org.archcnl.domain.TestUtils;
 import org.archcnl.domain.common.Concept;
 import org.archcnl.domain.common.Relation;
@@ -79,5 +82,19 @@ class ArchRulesFromAdocReaderTest {
                 rulesConceptsAndRelations.getRelationManager().getInputRelations()) {
             assertTrue(expectedModel.getRelationManager().getInputRelations().contains(relation));
         }
+    }
+    
+    @Test
+    void givenRulesAndMappingsInAdocFormat_whenMatchingPatterns_thenMatchesAreFound()
+    throws IOException {
+    	// given, when
+        final File ruleFile = new File("src/test/resources/ReaderParsingTest.adoc");
+        String rulesFileString = FileUtils.readFileToString(ruleFile, StandardCharsets.UTF_8);
+        // then
+    	assertEquals(2, TestUtils.numberOfMatches(ArchRulesFromAdocReader.getRulePattern(), rulesFileString));
+    	assertEquals(1, TestUtils.numberOfMatches(ArchRulesFromAdocReader.getConceptDescriptionPattern(), rulesFileString));
+    	assertEquals(1, TestUtils.numberOfMatches(ArchRulesFromAdocReader.getRelationDescriptionPattern(), rulesFileString));
+    	assertEquals(5, TestUtils.numberOfMatches(ArchRulesFromAdocReader.getRelationMappingPattern(), rulesFileString));
+    	assertEquals(3, TestUtils.numberOfMatches(ArchRulesFromAdocReader.getConceptMappingPattern(), rulesFileString));
     }
 }

--- a/web-ui/src/test/resources/ReaderParsingTest.adoc
+++ b/web-ui/src/test/resources/ReaderParsingTest.adoc
@@ -1,0 +1,54 @@
+==== Architecture Rules
+
+[role="rule"]
+Every Aggregate must resideIn a DomainRing.
+
+[role="rule"]
+No Aggregate can use an ApplicationService.
+
+
+==== Mapping for Concepts
+
+[role="description"]
+isAggregate: Every class whose name ends with Aggregate is an Aggregate.
+[role="mapping"]
+isAggregate: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '(\\w||\\W)*\\.(\\w||\\W)*Aggregate') -> (?class rdf:type architecture:Aggregate)
+
+[role="mapping"]
+isApplicationService: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:hasName ?name) regex(?name, 'api') (?package famix:namespaceContains ?class) -> (?class rdf:type architecture:ApplicationService)
+
+[role="description"]
+useMapping: A class uses another class if it has a field of it or if it imports it.
+[role="mapping"]
+useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClass) (?f rdf:type famix:Attribute) (?class famix:definesAttribute ?f) (?f famix:hasDeclaredType ?class2) -> (?class architecture:use ?class2)
+
+[role="mapping"]
+useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClass) (?class famix:imports ?class2) -> (?class architecture:use ?class2)
+
+[role="mapping"]
+isEmptyWhenConcept: -> (?var rdf:type architecture:EmptyWhenConcept)
+
+[role="mapping"]
+emptyWhenRelationStringMapping: -> (?var architecture:emptyWhenRelationString 'test string')
+
+[role="mapping"]
+emptyWhenRelationBooleanMapping: -> (?var architecture:emptyWhenRelationBoolean 'false'^^xsd:boolean)
+
+[role="mapping"]
+emptyWhenRelationVariableMapping: -> (?var architecture:emptyWhenRelationVariable ?test)
+
+
+==== Incorrectly written rules and mappings
+
+[role="rule"]
+
+This is not a correct rule as it is not in the line after its tag.
+
+[role="description"]
+This is not a correct description.
+
+[role="description"]
+isAggregate: This is also not a correct description, as brackets [] are not allowed.
+
+[role="mapping"]
+(?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClass) (?class famix:imports ?class2) -> (?class architecture:use ?class2)

--- a/web-ui/src/test/resources/architecture-documentation.adoc
+++ b/web-ui/src/test/resources/architecture-documentation.adoc
@@ -19,7 +19,7 @@ No Aggregate can use an ApplicationService.
 ==== Mapping for Concepts
 
 [role="description"]
-Every class whose name ends with Aggregate is an Aggregate.
+isAggregate: Every class whose name ends with Aggregate is an Aggregate.
 [role="mapping"]
 isAggregate: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '(\\w||\\W)*\\.(\\w||\\W)*Aggregate') -> (?class rdf:type architecture:Aggregate)
 
@@ -33,7 +33,7 @@ isDomainRing: (?package rdf:type famix:Namespace) (?package famix:hasName ?name)
 resideInMapping: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:namespaceContains ?class) -> (?class architecture:resideIn ?package)
 
 [role="description"]
-A class uses another class if it has a field of it or if it imports it.
+useMapping: A class uses another class if it has a field of it or if it imports it.
 [role="mapping"]
 useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClass) (?f rdf:type famix:Attribute) (?class famix:definesAttribute ?f) (?f famix:hasDeclaredType ?class2) -> (?class architecture:use ?class2)
 

--- a/web-ui/src/test/resources/architecture-documentation.adoc
+++ b/web-ui/src/test/resources/architecture-documentation.adoc
@@ -9,7 +9,6 @@ The following UML package diagram shows the main building blocks of the software
 
 
 ==== Architecture Rules
-
 [role="rule"]
 Every Aggregate must resideIn a DomainRing.
 
@@ -19,7 +18,8 @@ No Aggregate can use an ApplicationService.
 
 ==== Mapping for Concepts
 
-
+[role="description"]
+Every class whose name ends with Aggregate is an Aggregate.
 [role="mapping"]
 isAggregate: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '(\\w||\\W)*\\.(\\w||\\W)*Aggregate') -> (?class rdf:type architecture:Aggregate)
 
@@ -32,6 +32,8 @@ isDomainRing: (?package rdf:type famix:Namespace) (?package famix:hasName ?name)
 [role="mapping"]
 resideInMapping: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:namespaceContains ?class) -> (?class architecture:resideIn ?package)
 
+[role="description"]
+A class uses another class if it has a field of it or if it imports it.
 [role="mapping"]
 useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClass) (?f rdf:type famix:Attribute) (?class famix:definesAttribute ?f) (?f famix:hasDeclaredType ?class2) -> (?class architecture:use ?class2)
 


### PR DESCRIPTION
Descriptions in the adoc file are written like this:

[role="description"]
Every class whose name ends with Aggregate is an Aggregate.
[role="mapping"]
isAggregate: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '(\\w||\\W)*\\.(\\w||\\W)*Aggregate') -> (?class rdf:type architecture:Aggregate)

Descriptions should only contain alphanumeric characters, spaces and punctuation marks (.) and be contained in a single line.

I noticed the resideIn Mapping does not get imported to the GUI. Is this supposed to be like this? This happens on master aswell.