### PR TITLE
Bugfix/ArchCNL-64/rule-to-violation-mapping

### DIFF
--- a/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/api/StardogICVAPI.java
+++ b/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/api/StardogICVAPI.java
@@ -22,10 +22,9 @@ public interface StardogICVAPI {
      * ontology to the database.
      *
      * @param constraintModel The ontology modeling the constraints.
-     * @return A string representation of the added constraint.
      * @throws DBAccessException When accessing the database fails.
      */
-    public String addIntegrityConstraint(Model constraintModel) throws DBAccessException;
+    public void addIntegrityConstraint(Model constraintModel) throws DBAccessException;
 
     /** Connects to the given database and removes all integrity constraints from it. */
     void removeIntegrityConstraints();

--- a/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogICVAPIImpl.java
+++ b/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogICVAPIImpl.java
@@ -47,7 +47,7 @@ public class StardogICVAPIImpl implements StardogICVAPI {
     }
 
     @Override
-    public String addIntegrityConstraint(Model constraintModel) throws DBAccessException {
+    public void addIntegrityConstraint(Model constraintModel) throws DBAccessException {
         LOG.debug("Adding contraints to database");
         try (Connection aConn = establishConnection()) {
             ICVConnection aValidator = aConn.as(ICVConnection.class);
@@ -61,8 +61,7 @@ public class StardogICVAPIImpl implements StardogICVAPI {
             aValidator.addConstraints().format(RDFFormats.RDFXML).stream(reader);
 
             aConn.commit();
-
-            return aValidator.getConstraints().iterator().next().toString();
+            
         } catch (HttpClientException e) {
             LOG.error("Error while adding constraints to the database: ", e);
             throw new DBAccessException("Adding integrity constraints failed.", e);

--- a/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogICVAPIImpl.java
+++ b/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogICVAPIImpl.java
@@ -61,7 +61,7 @@ public class StardogICVAPIImpl implements StardogICVAPI {
             aValidator.addConstraints().format(RDFFormats.RDFXML).stream(reader);
 
             aConn.commit();
-            
+
         } catch (HttpClientException e) {
             LOG.error("Error while adding constraints to the database: ", e);
             throw new DBAccessException("Adding integrity constraints failed.", e);

--- a/toolchain/src/integration-test/java/org/archcnl/toolchain/ToolchainIT.java
+++ b/toolchain/src/integration-test/java/org/archcnl/toolchain/ToolchainIT.java
@@ -22,6 +22,10 @@ import org.junit.Assert;
 
 public class ToolchainIT {
 
+	private static final String FIRST_RULE_VIOLATED_QUERY = "queries/firstRuleViolated.sparql";
+    private static final String FIRST_RULE_CORRECTLY_MAPPED_QUERY = "queries/firstRuleCorrectlyMapped.sparql";
+    private static final String SECOND_RULE_VIOLATED_QUERY = "queries/secondRuleViolated.sparql";
+    private static final String SECOND_RULE_CORRECTLY_MAPPED_QUERY = "queries/secondRuleCorrectlyMapped.sparql";
     private final String rootDir = "./src/integration-test/resources/";
     private final String database = "archcnl_it_db";
     private final String server = "http://localhost:5820";
@@ -54,8 +58,10 @@ public class ToolchainIT {
         
         OntModel result = loadResult();
         // then
-        Assert.assertTrue(isFirstRuleViolated(result));
-        Assert.assertTrue(isSecondRuleViolated(result));
+        Assert.assertTrue(askQueryResult(result, FIRST_RULE_VIOLATED_QUERY));
+        Assert.assertTrue(askQueryResult(result, SECOND_RULE_VIOLATED_QUERY));
+        Assert.assertTrue(askQueryResult(result, FIRST_RULE_CORRECTLY_MAPPED_QUERY));
+        Assert.assertTrue(askQueryResult(result, SECOND_RULE_CORRECTLY_MAPPED_QUERY));
     }
 
     private OntModel loadResult() throws IOException {
@@ -78,12 +84,8 @@ public class ToolchainIT {
         db.closeConnectionToServer();
     }
     
-    private boolean isFirstRuleViolated(OntModel model) throws IOException {
-        return execAskQuery(Path.of(rootDir + "queries/firstRuleViolated.sparql"), model);
-    }
-    
-    private boolean isSecondRuleViolated(OntModel model) throws IOException {
-        return execAskQuery(Path.of(rootDir + "queries/secondRuleViolated.sparql"), model);
+    private boolean askQueryResult(OntModel model, String path) throws IOException {
+        return execAskQuery(Path.of(rootDir + path), model);
     }
     
     private boolean execAskQuery(Path queryPath, OntModel model) throws IOException {

--- a/toolchain/src/integration-test/java/org/archcnl/toolchain/ToolchainIT.java
+++ b/toolchain/src/integration-test/java/org/archcnl/toolchain/ToolchainIT.java
@@ -26,6 +26,7 @@ public class ToolchainIT {
     private static final String FIRST_RULE_CORRECTLY_MAPPED_QUERY = "queries/firstRuleCorrectlyMapped.sparql";
     private static final String SECOND_RULE_VIOLATED_QUERY = "queries/secondRuleViolated.sparql";
     private static final String SECOND_RULE_CORRECTLY_MAPPED_QUERY = "queries/secondRuleCorrectlyMapped.sparql";
+    private static final String THIRD_RULE_VIOLATED_QUERY = "queries/thirdRuleViolated.sparql";
     private final String rootDir = "./src/integration-test/resources/";
     private final String database = "archcnl_it_db";
     private final String server = "http://localhost:5820";
@@ -62,6 +63,7 @@ public class ToolchainIT {
         Assert.assertTrue(askQueryResult(result, SECOND_RULE_VIOLATED_QUERY));
         Assert.assertTrue(askQueryResult(result, FIRST_RULE_CORRECTLY_MAPPED_QUERY));
         Assert.assertTrue(askQueryResult(result, SECOND_RULE_CORRECTLY_MAPPED_QUERY));
+        Assert.assertFalse(askQueryResult(result, THIRD_RULE_VIOLATED_QUERY));
     }
 
     private OntModel loadResult() throws IOException {

--- a/toolchain/src/integration-test/resources/OnionArchitectureDemo/rules.adoc
+++ b/toolchain/src/integration-test/resources/OnionArchitectureDemo/rules.adoc
@@ -16,6 +16,9 @@ Every Aggregate must residein a DomainRing.
 [role="rule"]
 No Aggregate can use an ApplicationService.
 
+[role="rule"]
+Every View must have a Presenter.
+
 
 ==== Mapping for Concepts
 
@@ -37,3 +40,13 @@ useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClas
 
 [role="mapping"]
 useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClass) (?class famix:imports ?class2) -> (?class architecture:use ?class2)
+
+[role="mapping"]
+isView: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*View') (?class famix:isInterface 'false'^^xsd:boolean) -> (?class rdf:type architecture:View)
+
+[role="mapping"]
+isPresenter: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) regex(?name, '.*Presenter') (?class famix:isInterface 'false'^^xsd:boolean) -> (?class rdf:type architecture:Presenter)
+
+[role="mapping"]
+haveMapping: (?view rdf:type architecture:View) (?presenter rdf:type architecture:Presenter) (?view famix:hasName ?vName) (?presenter famix:hasName ?pName) regex(?vName, '(\\w*)View', ?vPrefix) regex(?pName, '(\\w*)Presenter', ?pPrefix) regex(?vPrefix, ?pPrefix) -> (?view architecture:have ?presenter) (?presenter architecture:have ?view)
+

--- a/toolchain/src/integration-test/resources/OnionArchitectureDemo/src/mvp/MainPresenter.java
+++ b/toolchain/src/integration-test/resources/OnionArchitectureDemo/src/mvp/MainPresenter.java
@@ -1,0 +1,5 @@
+package mvp;
+
+public class MainPresenter {
+
+}

--- a/toolchain/src/integration-test/resources/OnionArchitectureDemo/src/mvp/MainView.java
+++ b/toolchain/src/integration-test/resources/OnionArchitectureDemo/src/mvp/MainView.java
@@ -1,0 +1,5 @@
+package mvp;
+
+public class MainView {
+
+}

--- a/toolchain/src/integration-test/resources/queries/firstRuleCorrectlyMapped.sparql
+++ b/toolchain/src/integration-test/resources/queries/firstRuleCorrectlyMapped.sparql
@@ -1,0 +1,34 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX conformance: <http://arch-ont.org/ontologies/architectureconformance#>
+PREFIX famix: <http://arch-ont.org/ontologies/famix.owl#>
+PREFIX architecture: <http://www.arch-ont.org/ontologies/architecture.owl#>
+
+# Returns true when there are architecture violations. Otherwise, false is returned.
+
+ASK
+WHERE {
+    ?rule rdf:type conformance:ArchitectureRule.
+    ?rule conformance:hasRuleRepresentation "Every Aggregate must residein a DomainRing."^^xsd:string.
+    ?violation conformance:violates ?rule.
+    ?proof conformance:proofs ?violation.
+    ?proof conformance:hasAssertedStatement ?statement1.
+    ?proof conformance:hasNotInferredStatement ?statement2.
+    ?proof conformance:hasNotInferredStatement ?statement3.
+    
+    ?statement1 conformance:hasSubject ?s1.
+    ?statement1 conformance:hasPredicate rdf:type.
+    ?statement1 conformance:hasObject architecture:Aggregate.
+    ?s1 famix:hasFullQualifiedName "api.ValidationAggregate"^^xsd:string.
+    
+    ?statement2 conformance:hasSubject ?s2.
+    ?statement2 conformance:hasPredicate architecture:residein.
+    ?statement2 conformance:hasObject ?object.
+    ?s2 famix:hasFullQualifiedName "api.ValidationAggregate"^^xsd:string.
+    
+    ?statement3 conformance:hasSubject ?object.
+    ?statement3 conformance:hasPredicate rdf:type.
+    ?statement3 conformance:hasObject architecture:DomainRing.
+}

--- a/toolchain/src/integration-test/resources/queries/secondRuleCorrectlyMapped.sparql
+++ b/toolchain/src/integration-test/resources/queries/secondRuleCorrectlyMapped.sparql
@@ -1,0 +1,36 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX conformance: <http://arch-ont.org/ontologies/architectureconformance#>
+PREFIX famix: <http://arch-ont.org/ontologies/famix.owl#>
+PREFIX architecture: <http://www.arch-ont.org/ontologies/architecture.owl#>
+
+# Returns true when there are architecture violations. Otherwise, false is returned.
+
+ASK
+WHERE {
+    ?rule rdf:type conformance:ArchitectureRule.
+    ?rule conformance:hasRuleRepresentation "No Aggregate can use an ApplicationService."^^xsd:string.
+    ?violation conformance:violates ?rule.
+    ?proof conformance:proofs ?violation.
+    ?proof conformance:hasAssertedStatement ?statement1.
+    ?proof conformance:hasAssertedStatement ?statement2.
+    ?proof conformance:hasAssertedStatement ?statement3.
+    
+    ?statement1 conformance:hasSubject ?s1.
+    ?statement1 conformance:hasPredicate architecture:use.
+    ?statement1 conformance:hasObject ?o1.
+    ?s1 famix:hasFullQualifiedName "domain.UserAggregate"^^xsd:string.
+    ?o1 famix:hasFullQualifiedName "api.UserService"^^xsd:string.
+    
+    ?statement2 conformance:hasSubject ?s2.
+    ?statement2 conformance:hasPredicate rdf:type.
+    ?statement2 conformance:hasObject architecture:ApplicationService.
+    ?s2 famix:hasFullQualifiedName "api.UserService"^^xsd:string.
+    
+    ?statement3 conformance:hasSubject ?s3.
+    ?statement3 conformance:hasPredicate rdf:type.
+    ?statement3 conformance:hasObject architecture:Aggregate.
+    ?s3 famix:hasFullQualifiedName "domain.UserAggregate"^^xsd:string.
+}

--- a/toolchain/src/integration-test/resources/queries/thirdRuleViolated.sparql
+++ b/toolchain/src/integration-test/resources/queries/thirdRuleViolated.sparql
@@ -1,0 +1,12 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX conformance: <http://arch-ont.org/ontologies/architectureconformance#>
+
+# Returns true when there are architecture violations. Otherwise, false is returned.
+
+ASK
+WHERE {
+    ?rule rdf:type conformance:ArchitectureRule.
+    ?rule conformance:hasRuleRepresentation "Every View must have a Presenter."^^xsd:string.
+    ?violation conformance:violates ?rule.
+}

--- a/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
+++ b/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
@@ -46,7 +46,7 @@ public class CNLToolchain {
     private final IConformanceCheck check;
     private final StardogDatabaseAPI db;
     private Map<ArchitectureRule, ConstraintViolationsResultSet> ruleToViolationMapping =
-    	    new HashMap<ArchitectureRule, ConstraintViolationsResultSet>();
+            new HashMap<ArchitectureRule, ConstraintViolationsResultSet>();
 
     // mapping of name to transformer factories
     // add new parsers here
@@ -243,7 +243,8 @@ public class CNLToolchain {
 
             try {
                 icvAPI.addIntegrityConstraint(rule.getRuleModel());
-                ruleToViolationMapping.put(rule, icvAPI.explainViolationsForContext(context).get(0));
+                ruleToViolationMapping.put(
+                        rule, icvAPI.explainViolationsForContext(context).get(0));
                 icvAPI.removeIntegrityConstraints();
             } catch (DBAccessException e) {
                 LOG.error(e.getMessage());

--- a/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
+++ b/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
@@ -260,13 +260,13 @@ public class CNLToolchain {
 
     private void addViolationsToOntology(
             String tempfile,
-            Map<ArchitectureRule, ConstraintViolationsResultSet> violations,
+            Map<ArchitectureRule, ConstraintViolationsResultSet> ruleToViolationMapping,
             String resultPath)
             throws FileNotFoundException {
         check.createNewConformanceCheck();
-        for (ArchitectureRule rule : violations.keySet()) {
+        for (ArchitectureRule rule : ruleToViolationMapping.keySet()) {
             List<ConstraintViolation> violationsForRule;
-            violationsForRule = violations.get(rule).getViolationList();
+            violationsForRule = ruleToViolationMapping.get(rule).getViolationList();
 
             CheckedRule vr = new CheckedRule(rule, violationsForRule);
 

--- a/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
+++ b/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
@@ -244,7 +244,6 @@ public class CNLToolchain {
             try {
                 icvAPI.addIntegrityConstraint(rule.getRuleModel());
                 ruleToViolationMapping.put(rule, icvAPI.explainViolationsForContext(context).get(0));
-                LOG.info("Violations after rule: " + ruleToViolationMapping);
                 icvAPI.removeIntegrityConstraints();
             } catch (DBAccessException e) {
                 LOG.error(e.getMessage());


### PR DESCRIPTION
Each rule will now be put into the database as a constraint, then be checked, the result retrieved and then be deleted again from the database. This way rules can be mapped correctly to their corresponding violations. However if this approach has any negative effect on the performance is unknown.
Another thing to note is, that the used method to add the rules as constraints to the database is deprecated.

Closes #176