### PR TITLE
Enhancement/archcnl 111/or block labels2

### DIFF
--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/AndTripletsEditorPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/AndTripletsEditorPresenter.java
@@ -125,6 +125,7 @@ public class AndTripletsEditorPresenter extends Component {
         if (tripletPresenters.isEmpty()) {
             fireEvent(new DeleteAndTripletsViewRequestedEvent(view, false));
         }
+        view.updateLabels();
     }
 
     private Optional<TripletPresenter> findCorrespondingPresenter(TripletView tripletView) {

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/AndTripletsEditorView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/AndTripletsEditorView.java
@@ -11,9 +11,7 @@ import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.shared.Registration;
-
 import java.util.Optional;
-
 import org.archcnl.ui.input.mappingeditor.events.AddAndTripletsViewButtonPressedEvent;
 import org.archcnl.ui.input.mappingeditor.events.DeleteAndTripletsViewRequestedEvent;
 import org.archcnl.ui.input.mappingeditor.triplet.TripletView;
@@ -57,17 +55,19 @@ public class AndTripletsEditorView extends VerticalLayout {
     public void addNewTripletViewAfter(TripletView oldTripletView, TripletView newTripletView) {
         int previousIndex = boxContent.indexOf((Component) oldTripletView);
         boxContent.addComponentAtIndex(previousIndex + 1, newTripletView);
-        updateLabels();
     }
 
     public void deleteTripletView(TripletView tripletView) {
         boxContent.remove((Component) tripletView);
+
+        if (!getFirstTripletView().isPresent()) {
+            addTripletView(new TripletView());
+        }
         updateLabels();
     }
 
     public void addTripletView(TripletView tripletView) {
         boxContent.add(tripletView);
-        updateLabels();
     }
 
     public void clearContent() {
@@ -79,11 +79,13 @@ public class AndTripletsEditorView extends VerticalLayout {
             final Class<T> eventType, final ComponentEventListener<T> listener) {
         return getEventBus().addListener(eventType, listener);
     }
-    
-    public void updateLabels() {
-        Optional<Component> firstComponent =
-                boxContent.getChildren().filter(TripletView.class::isInstance).findFirst();
-        TripletView firstTriplet = (TripletView) firstComponent.get();
+
+    private void updateLabels() {
+        TripletView firstTriplet = (TripletView) getFirstTripletView().get();
         firstTriplet.setLabels();
+    }
+
+    private Optional<Component> getFirstTripletView() {
+        return boxContent.getChildren().filter(TripletView.class::isInstance).findFirst();
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/AndTripletsEditorView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/AndTripletsEditorView.java
@@ -10,8 +10,10 @@ import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.shared.Registration;
+
+import java.util.Optional;
+
 import org.archcnl.ui.input.mappingeditor.events.AddAndTripletsViewButtonPressedEvent;
 import org.archcnl.ui.input.mappingeditor.events.DeleteAndTripletsViewRequestedEvent;
 import org.archcnl.ui.input.mappingeditor.triplet.TripletView;
@@ -32,25 +34,6 @@ public class AndTripletsEditorView extends VerticalLayout {
         boxContent = new VerticalLayout();
         boxContent.getStyle().set("border", "1px solid black");
         boxContent.add(new Label("OR-Block (All rows in this block are AND connected)"));
-
-        HorizontalLayout tripletLabelLayout = new HorizontalLayout();
-        tripletLabelLayout.setWidthFull();
-
-        TextField subjectLabel = new TextField();
-        subjectLabel.setValue("Subject");
-        subjectLabel.setEnabled(false);
-
-        TextField predicateLabel = new TextField();
-        predicateLabel.setValue("Predicate");
-        predicateLabel.setEnabled(false);
-
-        TextField objectLabel = new TextField();
-        objectLabel.setValue("Object");
-        objectLabel.setEnabled(false);
-
-        tripletLabelLayout.add(subjectLabel, predicateLabel, objectLabel);
-
-        boxContent.add(tripletLabelLayout);
         boxContent.add(emptyTripletView);
         boxContent.setWidth(95, Unit.PERCENTAGE);
 
@@ -68,19 +51,23 @@ public class AndTripletsEditorView extends VerticalLayout {
 
         orBlock.add(boxContent, boxButtonLayout);
         add(orBlock);
+        updateLabels();
     }
 
     public void addNewTripletViewAfter(TripletView oldTripletView, TripletView newTripletView) {
         int previousIndex = boxContent.indexOf((Component) oldTripletView);
         boxContent.addComponentAtIndex(previousIndex + 1, newTripletView);
+        updateLabels();
     }
 
     public void deleteTripletView(TripletView tripletView) {
         boxContent.remove((Component) tripletView);
+        updateLabels();
     }
 
     public void addTripletView(TripletView tripletView) {
         boxContent.add(tripletView);
+        updateLabels();
     }
 
     public void clearContent() {
@@ -91,5 +78,12 @@ public class AndTripletsEditorView extends VerticalLayout {
     public <T extends ComponentEvent<?>> Registration addListener(
             final Class<T> eventType, final ComponentEventListener<T> listener) {
         return getEventBus().addListener(eventType, listener);
+    }
+    
+    public void updateLabels() {
+        Optional<Component> firstComponent =
+                boxContent.getChildren().filter(TripletView.class::isInstance).findFirst();
+        TripletView firstTriplet = (TripletView) firstComponent.get();
+        firstTriplet.setLabels();
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/AndTripletsEditorView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/AndTripletsEditorView.java
@@ -59,11 +59,6 @@ public class AndTripletsEditorView extends VerticalLayout {
 
     public void deleteTripletView(TripletView tripletView) {
         boxContent.remove((Component) tripletView);
-
-        if (!getFirstTripletView().isPresent()) {
-            addTripletView(new TripletView());
-        }
-        updateLabels();
     }
 
     public void addTripletView(TripletView tripletView) {
@@ -80,9 +75,11 @@ public class AndTripletsEditorView extends VerticalLayout {
         return getEventBus().addListener(eventType, listener);
     }
 
-    private void updateLabels() {
-        TripletView firstTriplet = (TripletView) getFirstTripletView().get();
-        firstTriplet.setLabels();
+    public void updateLabels() {
+        if (getFirstTripletView().isPresent()) {
+            TripletView firstTriplet = (TripletView) getFirstTripletView().get();
+            firstTriplet.setLabels();
+        }
     }
 
     private Optional<Component> getFirstTripletView() {

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/triplet/ObjectView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/triplet/ObjectView.java
@@ -26,6 +26,7 @@ public class ObjectView extends HorizontalLayout {
 
     private static final long serialVersionUID = -1105253743414019620L;
     private static final String CONCEPT = "Concept";
+    private static final String OBJECT = "Object";
     private static final String VAR_STRING_BOOL = "VariableStringBool";
     private ConceptSelectionComponent conceptSelectionComponent;
     private VariableStringBoolSelectionView variableStringBoolSelectionView;
@@ -129,9 +130,9 @@ public class ObjectView extends HorizontalLayout {
             final Class<T> eventType, final ComponentEventListener<T> listener) {
         return getEventBus().addListener(eventType, listener);
     }
-    
+
     public void setLabel() {
-        conceptSelectionComponent.setLabel("Object");
-        variableStringBoolSelectionView.setLabel("Object");
+        conceptSelectionComponent.setLabel(OBJECT);
+        variableStringBoolSelectionView.setLabel(OBJECT);
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/triplet/ObjectView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/triplet/ObjectView.java
@@ -129,4 +129,9 @@ public class ObjectView extends HorizontalLayout {
             final Class<T> eventType, final ComponentEventListener<T> listener) {
         return getEventBus().addListener(eventType, listener);
     }
+    
+    public void setLabel() {
+        conceptSelectionComponent.setLabel("Object");
+        variableStringBoolSelectionView.setLabel("Object");
+    }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/triplet/TripletView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/triplet/TripletView.java
@@ -73,7 +73,7 @@ public class TripletView extends HorizontalLayout {
     }
 
     private void addCreateRemoveButtons() {
-        HorizontalLayout buttons = new HorizontalLayout();        
+        HorizontalLayout buttons = new HorizontalLayout();
         buttons.add(
                 new Button(
                         new Icon(VaadinIcon.TRASH),

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/triplet/TripletView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/triplet/TripletView.java
@@ -73,14 +73,17 @@ public class TripletView extends HorizontalLayout {
     }
 
     private void addCreateRemoveButtons() {
-        add(
+        HorizontalLayout buttons = new HorizontalLayout();        
+        buttons.add(
                 new Button(
                         new Icon(VaadinIcon.TRASH),
                         click -> fireEvent(new TripletViewDeleteButtonPressedEvent(this))));
-        add(
+        buttons.add(
                 new Button(
                         new Icon(VaadinIcon.PLUS),
                         click -> fireEvent(new AddTripletViewAfterButtonPressedEvent(this))));
+        add(buttons);
+        setVerticalComponentAlignment(Alignment.END, buttons);
     }
 
     @Override

--- a/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/triplet/TripletView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/input/mappingeditor/triplet/TripletView.java
@@ -88,4 +88,10 @@ public class TripletView extends HorizontalLayout {
             final Class<T> eventType, final ComponentEventListener<T> listener) {
         return getEventBus().addListener(eventType, listener);
     }
+
+    public void setLabels() {
+        objectView.setLabel();
+        subjectComponent.setLabel("Subject");
+        predicateComponent.setLabel("Predicate");
+    }
 }


### PR DESCRIPTION
Readded the label functionality.  The labels "Subject", "Predicate" and "Object" now appear above the first tripletView in the orBlock.

Fixed a bug created with the mappingeditor rework that allowed the last tripletView to be deleted without creating a new one.