### PR TITLE
Only run check if open button was pressed

### DIFF
--- a/web-ui/src/main/java/org/archcnl/ui/MainPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/MainPresenter.java
@@ -65,7 +65,7 @@ public class MainPresenter extends Component implements PropertyChangeListener {
         SelectDirectoryDialog directoryDialog = new SelectDirectoryDialog(architectureCheck);
         directoryDialog.addOpenedChangeListener(
                 e -> {
-                    if (!e.isOpened()) {
+                    if (!e.isOpened() && directoryDialog.isOkButtonPressed()) {
                         checkViolations(directoryDialog.getSelectedPath());
                     }
                 });

--- a/web-ui/src/main/java/org/archcnl/ui/menudialog/SelectDirectoryDialog.java
+++ b/web-ui/src/main/java/org/archcnl/ui/menudialog/SelectDirectoryDialog.java
@@ -14,6 +14,7 @@ public class SelectDirectoryDialog extends Dialog implements FileSelectionDialog
     private static final long serialVersionUID = 5511746171215269619L;
     private Button confirmButton;
     private String selectedPath;
+    private boolean okButtonPressed = false;
 
     public SelectDirectoryDialog(ArchitectureCheck check) {
         setDraggable(true);
@@ -23,7 +24,7 @@ public class SelectDirectoryDialog extends Dialog implements FileSelectionDialog
 
         confirmButton =
                 new Button(
-                        "Open",
+                        "Run architecture check",
                         event -> {
                             Optional<File> file = fileSelectionComponent.getSelectedFile();
                             if (file.isEmpty()) {
@@ -33,6 +34,7 @@ public class SelectDirectoryDialog extends Dialog implements FileSelectionDialog
                                         "Please select a directory.");
                             } else {
                                 selectedPath = file.get().getPath();
+                                okButtonPressed = true;
                                 close();
                             }
                         });
@@ -47,6 +49,10 @@ public class SelectDirectoryDialog extends Dialog implements FileSelectionDialog
 
     public String getSelectedPath() {
         return selectedPath;
+    }
+
+    public boolean isOkButtonPressed() {
+        return okButtonPressed;
     }
 
     @Override


### PR DESCRIPTION
- Relating to implementation of #265 
- Noticed that it runs, even when cancel is pressed. This is fixed now.