### PR TITLE
Feature/arch cnl 158/add namespaces to ontology

### DIFF
--- a/conformance-checking/src/main/java/org/archcnl/conformancechecking/impl/ConformanceCheckOntologyClassesAndProperties.java
+++ b/conformance-checking/src/main/java/org/archcnl/conformancechecking/impl/ConformanceCheckOntologyClassesAndProperties.java
@@ -34,6 +34,13 @@ public class ConformanceCheckOntologyClassesAndProperties {
         return clazz.createIndividual(model, id);
     }
 
+    public static void resetCounters() {
+        violationId = 0;
+        proofId = 0;
+        assertedId = 0;
+        notInferredId = 0;
+    }
+
     public enum ConformanceCheckDatatypeProperties {
         hasCheckingDate,
         hasRuleRepresentation,

--- a/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/api/StardogDatabaseAPI.java
+++ b/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/api/StardogDatabaseAPI.java
@@ -3,6 +3,7 @@ package org.archcnl.stardogwrapper.api;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.archcnl.stardogwrapper.api.exceptions.NoConnectionToStardogServerException;
 
@@ -60,6 +61,14 @@ public interface StardogDatabaseAPI {
      * @param path The path to the file to which the retrieved model will be written.
      */
     void writeModelFromContextToFile(String context, String path);
+
+    /**
+     * Adds namespaces to the database, so that results of queries on the database have shortened
+     * names according to the defined namespaces.
+     *
+     * @param nsMap A map of prefixes with their iris
+     */
+    void addNamespaces(Map<String, String> nsMap);
 
     /** @return the server's name */
     String getServer();

--- a/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogDatabase.java
+++ b/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogDatabase.java
@@ -22,7 +22,9 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -131,6 +133,13 @@ public class StardogDatabase implements StardogDatabaseAPI {
     }
 
     @Override
+    public void addNamespaces(Map<String, String> nsMap) {
+        for (String prefix : nsMap.keySet()) {
+            connection.namespaces().add(prefix, nsMap.get(prefix));
+        }
+    }
+
+    @Override
     public String getServer() {
         return _server;
     }
@@ -185,12 +194,32 @@ public class StardogDatabase implements StardogDatabaseAPI {
                 ArrayList<String> singleResult = new ArrayList<String>();
                 for (String variableName : variables) {
                     // Extracting a String from the stardog result BindingSet
-                    singleResult.add(Value.lex(stardogResult.get(variableName)));
+                    Value value = stardogResult.get(variableName);
+                    if (value != null) {
+                        // Result is not shortened according to prefixes (like it would be on
+                        // stardog studio) and needs to
+                        // be shortened manually
+                        String iri = stripPrefixes(Value.lex(value));
+                        singleResult.add(iri);
+                    } else {
+                        singleResult.add("");
+                    }
                 }
                 queryResult.add(singleResult);
             }
             return queryResult;
         }
+    }
+
+    private String stripPrefixes(String string) {
+        Map<String, String> prefixMap = new HashMap<String, String>();
+        connection
+                .namespaces()
+                .forEach(namespace -> prefixMap.put(namespace.prefix(), namespace.iri()));
+        for (String prefix : prefixMap.keySet()) {
+            string = string.replace(prefixMap.get(prefix), prefix + ":");
+        }
+        return string;
     }
 
     private void printToConsole(SelectQueryResult results) {

--- a/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogDatabase.java
+++ b/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogDatabase.java
@@ -186,6 +186,11 @@ public class StardogDatabase implements StardogDatabaseAPI {
             List<String> variables = queryResults.variables();
             Result queryResult = new Result(variables);
 
+            Map<String, String> prefixMap = new HashMap<String, String>();
+            connection
+                    .namespaces()
+                    .forEach(namespace -> prefixMap.put(namespace.prefix(), namespace.iri()));
+
             while (queryResults.hasNext()) {
 
                 // Here we get the result from the query
@@ -197,9 +202,8 @@ public class StardogDatabase implements StardogDatabaseAPI {
                     Value value = stardogResult.get(variableName);
                     if (value != null) {
                         // Result is not shortened according to prefixes (like it would be on
-                        // stardog studio) and needs to
-                        // be shortened manually
-                        String iri = stripPrefixes(Value.lex(value));
+                        // stardog studio) and needs to be shortened manually
+                        String iri = stripPrefixes(Value.lex(value), prefixMap);
                         singleResult.add(iri);
                     } else {
                         singleResult.add("");
@@ -211,13 +215,9 @@ public class StardogDatabase implements StardogDatabaseAPI {
         }
     }
 
-    private String stripPrefixes(String string) {
-        Map<String, String> prefixMap = new HashMap<String, String>();
-        connection
-                .namespaces()
-                .forEach(namespace -> prefixMap.put(namespace.prefix(), namespace.iri()));
-        for (String prefix : prefixMap.keySet()) {
-            string = string.replace(prefixMap.get(prefix), prefix + ":");
+    private String stripPrefixes(String string, Map<String, String> namespaces) {
+        for (String prefix : namespaces.keySet()) {
+            string = string.replace(namespaces.get(prefix), prefix + ":");
         }
         return string;
     }

--- a/toolchain/src/integration-test/java/org/archcnl/toolchain/ToolchainIT.java
+++ b/toolchain/src/integration-test/java/org/archcnl/toolchain/ToolchainIT.java
@@ -64,6 +64,7 @@ public class ToolchainIT {
         Assert.assertTrue(askQueryResult(result, FIRST_RULE_CORRECTLY_MAPPED_QUERY));
         Assert.assertTrue(askQueryResult(result, SECOND_RULE_CORRECTLY_MAPPED_QUERY));
         Assert.assertFalse(askQueryResult(result, THIRD_RULE_VIOLATED_QUERY));
+        Assert.assertEquals(9, result.numPrefixes());
     }
 
     private OntModel loadResult() throws IOException {

--- a/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
+++ b/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
@@ -25,6 +25,7 @@ import org.archcnl.common.datatypes.ConstraintViolation;
 import org.archcnl.conformancechecking.api.CheckedRule;
 import org.archcnl.conformancechecking.api.IConformanceCheck;
 import org.archcnl.conformancechecking.impl.ConformanceCheckImpl;
+import org.archcnl.conformancechecking.impl.ConformanceCheckOntologyClassesAndProperties;
 import org.archcnl.javaparser.parser.JavaOntologyTransformer;
 import org.archcnl.kotlinparser.parser.KotlinOntologyTransformer;
 import org.archcnl.owlify.core.OwlifyComponent;
@@ -227,7 +228,19 @@ public class CNLToolchain {
 
         db.addDataByRDFFileAsNamedGraph(resultPath, context);
 
+        addNamespacesToOntology();
+
+        ConformanceCheckOntologyClassesAndProperties.resetCounters();
+
         LOG.info("CNLToolchain completed successfully!");
+    }
+
+    private void addNamespacesToOntology() {
+        Map<String, String> namespaces = new HashMap<>();
+        namespaces.put("architecture", "http://www.arch-ont.org/ontologies/architecture.owl#");
+        namespaces.put("conformance", "http://arch-ont.org/ontologies/architectureconformance#");
+        namespaces.put("famix", "http://arch-ont.org/ontologies/famix.owl");
+        db.addNamespaces(namespaces);
     }
 
     private void storeModelAndConstraintsInDB(

--- a/web-ui/src/main/resources/queries/violationsSubjectPredicateObject.sparql
+++ b/web-ui/src/main/resources/queries/violationsSubjectPredicateObject.sparql
@@ -25,4 +25,4 @@ GRAPH ?g
     }
   }
 }
-ORDER BY ?violation
+ORDER BY ?Violation


### PR DESCRIPTION
- Custom namespaces have been added to the database (Famix, Architecture, Conformance)
- Just with these namespaces queries where still not formated as they are when calling the same query from stardog studio. They should be in the prefix format, e.g.; famix:#FamixClass...
- There was no apparent way to directly do this, so now the results get manually shortened by any prefixes that they contain