### PR TITLE
Cleanup/rule creation gui

### DIFF
--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/conditioncomponents/ConditionStatementComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/conditioncomponents/ConditionStatementComponent.java
@@ -9,7 +9,10 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.shared.Registration;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
 import org.archcnl.ui.common.andtriplets.triplet.ConceptSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.PredicateSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.events.ConceptListUpdateRequestedEvent;
@@ -87,9 +90,13 @@ public class ConditionStatementComponent extends VerticalLayout implements RuleC
     }
 
     private void createVariableTextfield() {
-        variableTextfield = new VariableTextfieldWidget("[+-]?[0-9]+");
-        variableTextfield.setLabel("Concept, Interger or String");
-        variableTextfield.setPlaceholder("Concept, Interger or String");
+    	Set<String> regexSet = new HashSet<>();
+    	regexSet.add("[+-]?[0-9]+");
+    	regexSet.add("[A-Za-z]+");
+    	
+        variableTextfield = new VariableTextfieldWidget(regexSet);
+        variableTextfield.setLabel("Interger, String (or Concept)");
+        variableTextfield.setPlaceholder("Interger, String (or Concept)");
     }
 
     private void firstComboboxListener(String value) {

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/conditioncomponents/ConditionStatementComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/conditioncomponents/ConditionStatementComponent.java
@@ -31,7 +31,7 @@ public class ConditionStatementComponent extends VerticalLayout implements RuleC
     private Checkbox andCheckbox;
     private ConditionStatementComponent newCondition;
     private HorizontalLayout conditionBox;
-    private boolean conceptRequired = true;
+    private boolean usesConcept = true;
 
     public ConditionStatementComponent() {
         setMargin(false);
@@ -105,12 +105,26 @@ public class ConditionStatementComponent extends VerticalLayout implements RuleC
             case "an":
             case "equal-to a":
             case "equal-to an":
-                conditionBox.replace(variableTextfield, conceptCombobox);
-                conceptRequired = true;
+            	conditionBox.removeAll();
+            	conditionBox.add(
+                        startLabelTextfield,
+                        relationCombobox,
+                        modifierCombobox,
+                        conceptCombobox,
+                        endLabelTextfield,
+                        andCheckbox);
+                usesConcept = true;
                 break;
             default:
-                conditionBox.replace(conceptCombobox, variableTextfield);
-                conceptRequired = false;
+            	conditionBox.removeAll();
+            	conditionBox.add(
+                        startLabelTextfield,
+                        relationCombobox,
+                        modifierCombobox,
+                        variableTextfield,
+                        endLabelTextfield,
+                        andCheckbox);
+                usesConcept = false;
                 break;
         }
     }
@@ -135,7 +149,7 @@ public class ConditionStatementComponent extends VerticalLayout implements RuleC
         sBuilder.append(relationCombobox.getValue() + " ");
         sBuilder.append(modifierCombobox.getValue() + " ");
 
-        if (conceptRequired) {
+        if (usesConcept) {
             sBuilder.append(conceptCombobox.getValue());
         } else {
             sBuilder.append(variableTextfield.getValue());

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/conditioncomponents/ConditionStatementComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/conditioncomponents/ConditionStatementComponent.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import org.archcnl.ui.common.andtriplets.triplet.ConceptSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.PredicateSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.events.ConceptListUpdateRequestedEvent;
@@ -32,6 +31,8 @@ public class ConditionStatementComponent extends VerticalLayout implements RuleC
     private ConditionStatementComponent newCondition;
     private HorizontalLayout conditionBox;
     private boolean usesConcept = true;
+    private final String CHAR_REGEX = "[A-Za-z]+";
+    private final String INTEGER_REGEX = "[+-]?[0-9]+";
 
     public ConditionStatementComponent() {
         setMargin(false);
@@ -90,10 +91,10 @@ public class ConditionStatementComponent extends VerticalLayout implements RuleC
     }
 
     private void createVariableTextfield() {
-    	Set<String> regexSet = new HashSet<>();
-    	regexSet.add("[+-]?[0-9]+");
-    	regexSet.add("[A-Za-z]+");
-    	
+        Set<String> regexSet = new HashSet<>();
+        regexSet.add(CHAR_REGEX);
+        regexSet.add(INTEGER_REGEX);
+
         variableTextfield = new VariableTextfieldWidget(regexSet);
         variableTextfield.setLabel("Interger, String (or Concept)");
         variableTextfield.setPlaceholder("Interger, String (or Concept)");
@@ -105,8 +106,8 @@ public class ConditionStatementComponent extends VerticalLayout implements RuleC
             case "an":
             case "equal-to a":
             case "equal-to an":
-            	conditionBox.removeAll();
-            	conditionBox.add(
+                conditionBox.removeAll();
+                conditionBox.add(
                         startLabelTextfield,
                         relationCombobox,
                         modifierCombobox,
@@ -116,8 +117,8 @@ public class ConditionStatementComponent extends VerticalLayout implements RuleC
                 usesConcept = true;
                 break;
             default:
-            	conditionBox.removeAll();
-            	conditionBox.add(
+                conditionBox.removeAll();
+                conditionBox.add(
                         startLabelTextfield,
                         relationCombobox,
                         modifierCombobox,

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/conditioncomponents/ConditionStatementComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/conditioncomponents/ConditionStatementComponent.java
@@ -101,30 +101,17 @@ public class ConditionStatementComponent extends VerticalLayout implements RuleC
     }
 
     private void firstComboboxListener(String value) {
+        conditionBox.remove(conceptCombobox, variableTextfield, endLabelTextfield, andCheckbox);
         switch (value) {
             case "a":
             case "an":
             case "equal-to a":
             case "equal-to an":
-                conditionBox.removeAll();
-                conditionBox.add(
-                        startLabelTextfield,
-                        relationCombobox,
-                        modifierCombobox,
-                        conceptCombobox,
-                        endLabelTextfield,
-                        andCheckbox);
+                conditionBox.add(conceptCombobox, endLabelTextfield, andCheckbox);
                 usesConcept = true;
                 break;
             default:
-                conditionBox.removeAll();
-                conditionBox.add(
-                        startLabelTextfield,
-                        relationCombobox,
-                        modifierCombobox,
-                        variableTextfield,
-                        endLabelTextfield,
-                        andCheckbox);
+                conditionBox.add(variableTextfield, endLabelTextfield, andCheckbox);
                 usesConcept = false;
                 break;
         }

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/textfieldwidgets/VariableTextfieldWidget.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/textfieldwidgets/VariableTextfieldWidget.java
@@ -1,8 +1,7 @@
 package org.archcnl.ui.inputview.rulesormappingeditorview.architectureruleeditor.components.textfieldwidgets;
 
-import java.util.Set;
-
 import com.vaadin.flow.component.textfield.TextField;
+import java.util.Set;
 
 public class VariableTextfieldWidget extends TextField {
 
@@ -17,32 +16,28 @@ public class VariableTextfieldWidget extends TextField {
                 });
     }
 
-    public void addRegex(String Regex)
-    {
-    	regexPatternList.add(Regex);
+    public void addRegex(String Regex) {
+        regexPatternList.add(Regex);
     }
-    
-    public void removeRegex(String Regex)
-    {
-    	regexPatternList.remove(Regex);
+
+    public void removeRegex(String Regex) {
+        regexPatternList.remove(Regex);
     }
 
     private void checkRegex() {
         boolean validInput = false;
-    	for (String regexString : regexPatternList) 
-        {
-			if(getValue().matches(regexString)) {
-				validInput = true;
-			}
-		}
-    	showErrorMessage(validInput);
+        for (String regexString : regexPatternList) {
+            if (getValue().matches(regexString)) {
+                validInput = true;
+            }
+        }
+        showErrorMessage(validInput);
     }
 
-    private void showErrorMessage(boolean showError) {
-        if(showError)
-        {
-        	setErrorMessage("Invalid Input");
+    private void showErrorMessage(boolean validInput) {
+        if (!validInput) {
+            setErrorMessage("Invalid Input");
             setInvalid(true);
-        }    	
+        }
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/textfieldwidgets/VariableTextfieldWidget.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/textfieldwidgets/VariableTextfieldWidget.java
@@ -1,36 +1,48 @@
 package org.archcnl.ui.inputview.rulesormappingeditorview.architectureruleeditor.components.textfieldwidgets;
 
+import java.util.Set;
+
 import com.vaadin.flow.component.textfield.TextField;
 
 public class VariableTextfieldWidget extends TextField {
 
     private static final long serialVersionUID = 1L;
-    private String regexPattern;
+    private Set<String> regexPatternList;
 
-    public VariableTextfieldWidget(String regex) {
-        regexPattern = regex;
+    public VariableTextfieldWidget(Set<String> regex) {
+        regexPatternList = regex;
         addValueChangeListener(
                 e -> {
                     checkRegex();
                 });
     }
 
-    public VariableTextfieldWidget(String regex, String regex2) {
-        regexPattern = regex;
-        addValueChangeListener(
-                e -> {
-                    checkRegex();
-                });
+    public void addRegex(String Regex)
+    {
+    	regexPatternList.add(Regex);
+    }
+    
+    public void removeRegex(String Regex)
+    {
+    	regexPatternList.remove(Regex);
     }
 
-    public void checkRegex() {
-        if (!getValue().matches(regexPattern)) {
-            // showErrorMessage("Incorrect Input");
-        }
+    private void checkRegex() {
+        boolean validInput = false;
+    	for (String regexString : regexPatternList) 
+        {
+			if(getValue().matches(regexString)) {
+				validInput = true;
+			}
+		}
+    	showErrorMessage(validInput);
     }
 
-    public void showErrorMessage(String message) {
-        setErrorMessage(message);
-        setInvalid(true);
+    private void showErrorMessage(boolean showError) {
+        if(showError)
+        {
+        	setErrorMessage("Invalid Input");
+            setInvalid(true);
+        }    	
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/DefaultStatementComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/DefaultStatementComponent.java
@@ -13,7 +13,10 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.shared.Registration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
 import org.archcnl.ui.common.andtriplets.triplet.ConceptSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.PredicateSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.events.ConceptListUpdateRequestedEvent;
@@ -38,6 +41,8 @@ public class DefaultStatementComponent extends VerticalLayout implements RuleCom
     private Component[] buildingBlock;
     private SelectionState currentState;
     private boolean isAndOrBlock = false;
+    private final String CHAR_REGEX = "[A-Za-z]+";
+    private final String INTEGER_REGEX = "[+-]?[0-9]+";
     private ArrayList<String> secondModifierList =
             new ArrayList<>(
                     Arrays.asList(
@@ -121,7 +126,10 @@ public class DefaultStatementComponent extends VerticalLayout implements RuleCom
                     determineState();
                 });
 
-        four_secondVariable = new VariableTextfieldWidget("/[+-]?[0-9]+");
+        Set<String> regexSet = new HashSet<>();
+    	regexSet.add(INTEGER_REGEX);
+    	regexSet.add(CHAR_REGEX);
+        four_secondVariable = new VariableTextfieldWidget(regexSet);
         four_secondVariable.setPlaceholder("+/- [0-9] / String");
         four_secondVariable.setLabel("Integer or String");
 
@@ -266,11 +274,13 @@ public class DefaultStatementComponent extends VerticalLayout implements RuleCom
                     || currentState == SelectionState.DEFAULTNUMBERBRANCHWITHCONDITION) {
                 four_secondVariable.setPlaceholder("+/- [0-9]");
                 four_secondVariable.setLabel("Integer");
+                four_secondVariable.removeRegex(CHAR_REGEX);
             }
 
             if (currentState == SelectionState.EQUALTOVARIABLEBRANCH) {
                 four_secondVariable.setPlaceholder("+/- [0-9] / String");
                 four_secondVariable.setLabel("Integer or String");
+                four_secondVariable.addRegex(INTEGER_REGEX);
             }
         }
         // Hide / Show condition

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/DefaultStatementComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/DefaultStatementComponent.java
@@ -40,7 +40,7 @@ public class DefaultStatementComponent extends VerticalLayout implements RuleCom
     private Checkbox six_addConditionCheckbox;
     private Component[] buildingBlock;
     private SelectionState currentState;
-    private boolean isAndOrBlock = false;
+    private boolean isAndOrBlock = false, addModifiers = true;
     private final String CHAR_REGEX = "[A-Za-z]+";
     private final String INTEGER_REGEX = "[+-]?[0-9]+";
     private ArrayList<String> secondModifierList =
@@ -101,11 +101,12 @@ public class DefaultStatementComponent extends VerticalLayout implements RuleCom
         }
     }
 
-    public DefaultStatementComponent(Boolean andOrBlock) {
+    public DefaultStatementComponent(Boolean andOrBlock, Boolean everySubjectDescriptor) {
         this.setMargin(false);
         this.setPadding(false);
         isAndOrBlock = andOrBlock;
-
+        addModifiers = everySubjectDescriptor;
+        
         initializeLayout();
         determineState();
     }
@@ -183,16 +184,21 @@ public class DefaultStatementComponent extends VerticalLayout implements RuleCom
                     });
             return;
         }
-        List<String> modifierList =
-                Arrays.asList("must", "can-only", "can", "must be", "must be a", "must be an");
+        //AndOrBlocks can't choose anything/equal-to anything
+        secondModifierList.addAll(Arrays.asList("anything", "equal-to anything"));
+        
+        List<String> modifierList = new ArrayList<>();
+        modifierList.add("can");
+        if(addModifiers)
+        {
+        	modifierList.addAll(Arrays.asList("can-only", "must", "must be", "must be a", "must be an"));
+        }     
         one_firstCombobox = new ComboBox<String>("Modifier", modifierList);
-        one_firstCombobox.setValue("must");
+        one_firstCombobox.setValue("can");
         one_firstCombobox.addValueChangeListener(
                 e -> {
                     determineState();
-                });
-
-        secondModifierList.addAll(Arrays.asList("anything", "equal-to anything"));
+                });   
     }
 
     private void initializeAndOrButtons() {

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/DefaultStatementComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/DefaultStatementComponent.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import org.archcnl.ui.common.andtriplets.triplet.ConceptSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.PredicateSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.events.ConceptListUpdateRequestedEvent;
@@ -106,7 +105,7 @@ public class DefaultStatementComponent extends VerticalLayout implements RuleCom
         this.setPadding(false);
         isAndOrBlock = andOrBlock;
         addModifiers = everySubjectDescriptor;
-        
+
         initializeLayout();
         determineState();
     }
@@ -128,9 +127,10 @@ public class DefaultStatementComponent extends VerticalLayout implements RuleCom
                 });
 
         Set<String> regexSet = new HashSet<>();
-    	regexSet.add(INTEGER_REGEX);
-    	regexSet.add(CHAR_REGEX);
+        regexSet.add(CHAR_REGEX);
+        regexSet.add(INTEGER_REGEX);
         four_secondVariable = new VariableTextfieldWidget(regexSet);
+
         four_secondVariable.setPlaceholder("+/- [0-9] / String");
         four_secondVariable.setLabel("Integer or String");
 
@@ -184,21 +184,21 @@ public class DefaultStatementComponent extends VerticalLayout implements RuleCom
                     });
             return;
         }
-        //AndOrBlocks can't choose anything/equal-to anything
+        // AndOrBlocks can't choose anything/equal-to anything
         secondModifierList.addAll(Arrays.asList("anything", "equal-to anything"));
-        
+
         List<String> modifierList = new ArrayList<>();
         modifierList.add("can");
-        if(addModifiers)
-        {
-        	modifierList.addAll(Arrays.asList("can-only", "must", "must be", "must be a", "must be an"));
-        }     
+        if (addModifiers) {
+            modifierList.addAll(
+                    Arrays.asList("can-only", "must", "must be", "must be a", "must be an"));
+        }
         one_firstCombobox = new ComboBox<String>("Modifier", modifierList);
         one_firstCombobox.setValue("can");
         one_firstCombobox.addValueChangeListener(
                 e -> {
                     determineState();
-                });   
+                });
     }
 
     private void initializeAndOrButtons() {
@@ -286,7 +286,7 @@ public class DefaultStatementComponent extends VerticalLayout implements RuleCom
             if (currentState == SelectionState.EQUALTOVARIABLEBRANCH) {
                 four_secondVariable.setPlaceholder("+/- [0-9] / String");
                 four_secondVariable.setLabel("Integer or String");
-                four_secondVariable.addRegex(INTEGER_REGEX);
+                four_secondVariable.addRegex(CHAR_REGEX);
             }
         }
         // Hide / Show condition

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/FactStatementComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/FactStatementComponent.java
@@ -9,7 +9,6 @@ import com.vaadin.flow.shared.Registration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.archcnl.ui.common.andtriplets.triplet.ConceptSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.PredicateSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.events.ConceptListUpdateRequestedEvent;
@@ -27,6 +26,8 @@ public class FactStatementComponent extends VerticalLayout implements RuleCompon
     private VariableTextfieldWidget fourB_thirdVariable;
     private PredicateSelectionComponent twoB_firstVariable_Relation;
     private boolean isInUpperBranch = false, conceptRequired = true;
+    private final String CHAR_REGEX = "[A-Za-z]+";
+    private final String INTEGER_REGEX = "[+-]?[0-9]+";
 
     public FactStatementComponent() {
         this.setMargin(false);
@@ -85,10 +86,10 @@ public class FactStatementComponent extends VerticalLayout implements RuleCompon
 
     private VariableTextfieldWidget createTextfieldWidget() {
         Set<String> regexSet = new HashSet<>();
-    	regexSet.add("[+-]?[0-9]+");
-    	regexSet.add("[A-Za-z]+");    	
-    	VariableTextfieldWidget freeTextVariable =
-                new VariableTextfieldWidget(regexSet);
+        regexSet.add(CHAR_REGEX);
+        regexSet.add(INTEGER_REGEX);
+        VariableTextfieldWidget freeTextVariable = new VariableTextfieldWidget(regexSet);
+
         freeTextVariable.setPlaceholder("+/- [0-9] / String");
         freeTextVariable.setLabel("Integer or String");
         return freeTextVariable;

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/FactStatementComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/FactStatementComponent.java
@@ -7,6 +7,9 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.shared.Registration;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.archcnl.ui.common.andtriplets.triplet.ConceptSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.PredicateSelectionComponent;
 import org.archcnl.ui.common.andtriplets.triplet.events.ConceptListUpdateRequestedEvent;
@@ -81,8 +84,11 @@ public class FactStatementComponent extends VerticalLayout implements RuleCompon
     }
 
     private VariableTextfieldWidget createTextfieldWidget() {
-        VariableTextfieldWidget freeTextVariable =
-                new VariableTextfieldWidget("(([+-]?[0-9]+)|[a-z]+])");
+        Set<String> regexSet = new HashSet<>();
+    	regexSet.add("[+-]?[0-9]+");
+    	regexSet.add("[A-Za-z]+");    	
+    	VariableTextfieldWidget freeTextVariable =
+                new VariableTextfieldWidget(regexSet);
         freeTextVariable.setPlaceholder("+/- [0-9] / String");
         freeTextVariable.setLabel("Integer or String");
         return freeTextVariable;

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/StatementComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/StatementComponent.java
@@ -29,7 +29,7 @@ public class StatementComponent extends VerticalLayout implements RuleComponentI
         this.getStyle().set("border", "1px solid black");
         this.setMargin(false);
 
-        determineVerbComponent("");
+        determineVerbComponent("Every");
     }
 
     /**
@@ -38,7 +38,8 @@ public class StatementComponent extends VerticalLayout implements RuleComponentI
      * shown.
      */
     public void determineVerbComponent(String selectedDescriptor) {
-        if (determineState(selectedDescriptor) == determineState(currentSubjectSelection)) {
+        int selectedState = determineState(selectedDescriptor);
+    	if (selectedState == determineState(currentSubjectSelection)) {
             return;
         }
 
@@ -68,7 +69,7 @@ public class StatementComponent extends VerticalLayout implements RuleComponentI
                 break;
             default:
                 DefaultStatementComponent defaultVerbComponent =
-                        new DefaultStatementComponent(false);
+                        new DefaultStatementComponent(false, selectedState == 3);
                 defaultVerbComponent.addListener(
                         RelationListUpdateRequestedEvent.class, this::fireEvent);
                 defaultVerbComponent.addListener(
@@ -95,15 +96,20 @@ public class StatementComponent extends VerticalLayout implements RuleComponentI
             case "Fact:":
                 currentState = 2;
                 break;
+            case "Every":
+            case "Every a":
+            case "Every an":
+            	currentState = 3;
+            	break;
             default:
-                currentState = 3;
+                currentState = 4;
                 break;
         }
         return currentState;
     }
 
     private void addAndOrVerbComponent() {
-        DefaultStatementComponent andOrVerbComponent = new DefaultStatementComponent(true);
+        DefaultStatementComponent andOrVerbComponent = new DefaultStatementComponent(true, false);
         andOrVerbComponent.addListener(
                 AddAndOrStatementComponentEvent.class, event -> addAndOrVerbComponent());
         andOrVerbComponent.addListener(

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/StatementComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/components/verbcomponents/StatementComponent.java
@@ -39,7 +39,7 @@ public class StatementComponent extends VerticalLayout implements RuleComponentI
      */
     public void determineVerbComponent(String selectedDescriptor) {
         int selectedState = determineState(selectedDescriptor);
-    	if (selectedState == determineState(currentSubjectSelection)) {
+        if (selectedState == determineState(currentSubjectSelection)) {
             return;
         }
 
@@ -99,8 +99,8 @@ public class StatementComponent extends VerticalLayout implements RuleComponentI
             case "Every":
             case "Every a":
             case "Every an":
-            	currentState = 3;
-            	break;
+                currentState = 3;
+                break;
             default:
                 currentState = 4;
                 break;


### PR DESCRIPTION
Fixed a bug where the order of components inside the ConditionStatementComponent would get messed up.
Fixed the regex check for the VariableTextfieldWidget.
Realized that unlike the "Every" branch, the "Only"/"Nothing"/"No" branches of the grammar tree only allowed "can" as a first modifier.