### PR TITLE
Reorder and auto-run all predefined queries

### DIFF
--- a/web-ui/src/main/java/org/archcnl/domain/output/model/query/QueryUtils.java
+++ b/web-ui/src/main/java/org/archcnl/domain/output/model/query/QueryUtils.java
@@ -29,7 +29,7 @@ public class QueryUtils {
             "# An error occured while trying to load the query.\r\n" + "SELECT * WHERE {}";
 
     public static String getDefaultQuery() {
-        return getQueryFromQueryDirectory(VIOLATIONS_WITH_FAMIX_NAMES);
+        return getQueryFromQueryDirectory(MINIMALISTIC_VIOLATIONINSTANCES);
     }
 
     public static String getQueryFromQueryDirectory(Path path) {
@@ -42,17 +42,17 @@ public class QueryUtils {
     }
 
     public static List<PredefinedQuery> getPredefinedQueries() {
-        List<PredefinedQuery> predefinedQueries = new LinkedList<PredefinedQuery>();
+        List<PredefinedQuery> predefinedQueries = new LinkedList<>();
         predefinedQueries.add(
                 new PredefinedQuery(
-                        "Locations of Violations",
+                        "More Details",
+                        "This query returns violated rules and the objects that are involved in those violations.",
+                        getQueryFromQueryDirectory(VIOLATIONS_WITH_FAMIX_NAMES)));
+        predefinedQueries.add(
+                new PredefinedQuery(
+                        "Violation Locations",
                         "This query returns the architecture violations with their corresponding locations.",
                         getQueryFromQueryDirectory(VIOLATIONS_WITH_LOCATIONS)));
-        predefinedQueries.add(
-                new PredefinedQuery(
-                        "Minimalistic Violations",
-                        "This query returns violated rules and the objects that are involved in those violations.",
-                        getQueryFromQueryDirectory(MINIMALISTIC_VIOLATIONINSTANCES)));
         return predefinedQueries;
     }
 

--- a/web-ui/src/main/java/org/archcnl/ui/MainPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/MainPresenter.java
@@ -16,7 +16,6 @@ import org.archcnl.domain.common.RelationManager;
 import org.archcnl.domain.common.exceptions.ConceptDoesNotExistException;
 import org.archcnl.domain.input.model.architecturerules.ArchitectureRule;
 import org.archcnl.domain.input.model.architecturerules.ArchitectureRuleManager;
-import org.archcnl.domain.output.model.query.QueryUtils;
 import org.archcnl.ui.common.andtriplets.triplet.events.ConceptListUpdateRequestedEvent;
 import org.archcnl.ui.common.andtriplets.triplet.events.ConceptSelectedEvent;
 import org.archcnl.ui.common.andtriplets.triplet.events.PredicateSelectedEvent;
@@ -101,10 +100,7 @@ public class MainPresenter extends Component {
             if (path.isPresent()) {
                 runArchCnlToolchain(architectureCheck, path.get());
             }
-            outputPresenter.displayResult(
-                    architectureCheck
-                            .getRepository()
-                            .executeNativeSelectQuery(QueryUtils.getDefaultQuery()));
+            outputPresenter.displayResult();
             view.showContent(outputPresenter.getView());
             view.setOpenProjectMenuItemEnabled(false);
         } catch (PropertyNotFoundException e2) {

--- a/web-ui/src/main/java/org/archcnl/ui/outputview/OutputView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/outputview/OutputView.java
@@ -68,12 +68,18 @@ public class OutputView extends HorizontalLayout {
     }
 
     public void displayResult(
-            final Optional<Result> result,
+            final Optional<Result> defaultQueryResult,
+            List<Optional<Result>> predefinedQueryResults,
             String nrOfViolations,
             String nrOfPackages,
             String nrOfRelationships,
             String nrOfTypes) {
-        defaultQueryView.updateGridView(result);
+        defaultQueryView.updateGridView(defaultQueryResult);
+        for (int i = 0;
+                i < Math.min(predefinedQueryResults.size(), predefinedQueries.size());
+                i++) {
+            predefinedQueries.get(i).updateGridView(predefinedQueryResults.get(i));
+        }
         defaultQueryView.updateGeneralInfoLayout(
                 nrOfViolations, nrOfPackages, nrOfRelationships, nrOfTypes);
     }

--- a/web-ui/src/main/java/org/archcnl/ui/outputview/queryviews/PredefinedQueryComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/outputview/queryviews/PredefinedQueryComponent.java
@@ -1,9 +1,9 @@
 package org.archcnl.ui.outputview.queryviews;
 
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Label;
+import java.util.Optional;
 import org.archcnl.domain.output.model.query.PredefinedQuery;
-import org.archcnl.ui.outputview.queryviews.events.RunQueryRequestedEvent;
+import org.archcnl.stardogwrapper.api.StardogDatabaseAPI.Result;
 
 public class PredefinedQueryComponent extends AbstractQueryComponent {
 
@@ -11,11 +11,6 @@ public class PredefinedQueryComponent extends AbstractQueryComponent {
 
     private final String name;
     private final Label description;
-
-    private Button runButton =
-            new Button(
-                    "Run",
-                    e -> fireEvent(new RunQueryRequestedEvent(this, true, getQuery(), gridView)));
 
     public PredefinedQueryComponent(PredefinedQuery query) {
         super(query.getQueryString());
@@ -25,11 +20,15 @@ public class PredefinedQueryComponent extends AbstractQueryComponent {
         addComponents();
     }
 
+    public void updateGridView(final Optional<Result> result) {
+        gridView.update(result);
+    }
+
     public String getName() {
         return name;
     }
 
     protected void addComponents() {
-        add(description, queryTextArea, runButton, gridView);
+        add(description, gridView, queryTextArea);
     }
 }

--- a/web-ui/src/main/resources/queries/minimalisticViolatingInstances.sparql
+++ b/web-ui/src/main/resources/queries/minimalisticViolatingInstances.sparql
@@ -5,7 +5,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX conformance: <http://arch-ont.org/ontologies/architectureconformance#>
 PREFIX famix: <http://arch-ont.org/ontologies/famix.owl#>
 PREFIX architecture: <http://www.arch-ont.org/ontologies/architecture.owl#>
-SELECT DISTINCT ?Rule ?Violation ?ViolatingObject
+SELECT DISTINCT ?Rule ?Violation ?ViolatingObject ?Location
 WHERE {
 GRAPH ?g
   {
@@ -16,6 +16,7 @@ GRAPH ?g
     ?proof conformance:hasAssertedStatement ?statement.
     ?statement conformance:hasSubject ?subject.
     ?subject famix:hasFullQualifiedName ?ViolatingObject.
+    OPTIONAL {?subject famix:isLocatedAt ?Location.}
   }
 }
 ORDER BY ?Violation


### PR DESCRIPTION
- In the general information tab the user is now presented with the minimalistic query appended by the location
- The query results table is placed above the query text for predefined queries just like for the default query
- All predefined queries are auto-executed together with the default query