### PR TITLE
Type checker looks recursively for super types

### DIFF
--- a/web-ui/src/main/java/org/archcnl/domain/common/RelationManager.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/RelationManager.java
@@ -26,10 +26,12 @@ import org.archcnl.domain.input.model.mappings.RelationMapping;
 public class RelationManager extends HierarchyManager<Relation> {
 
     private List<Relation> relations;
+    private ConceptManager conceptManager;
 
     public RelationManager(final ConceptManager conceptManager)
             throws ConceptDoesNotExistException {
-        relations = new LinkedList<>();
+        this.relations = new LinkedList<>();
+        this.conceptManager = conceptManager;
 
         addHierarchyRoot("Default Relations");
         addHierarchyRoot("Custom Relations");
@@ -100,7 +102,7 @@ public class RelationManager extends HierarchyManager<Relation> {
                     if (existingMapping.isPresent() && newMapping.isPresent()) {
                         existingMapping.get().addAllAndTriplets(newMapping.get().getWhenTriplets());
                     } else if (existingMapping.isEmpty() && newMapping.isPresent()) {
-                        existingCustomRelation.setMapping(newMapping.get());
+                        existingCustomRelation.setMapping(newMapping.get(), conceptManager);
                     }
                 }
             }

--- a/web-ui/src/main/java/org/archcnl/domain/common/conceptsandrelations/CustomRelation.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/conceptsandrelations/CustomRelation.java
@@ -3,6 +3,7 @@ package org.archcnl.domain.common.conceptsandrelations;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
+import org.archcnl.domain.common.ConceptManager;
 import org.archcnl.domain.common.FormattedQueryDomainObject;
 import org.archcnl.domain.common.VariableManager;
 import org.archcnl.domain.common.conceptsandrelations.andtriplets.triplet.ActualObjectType;
@@ -26,7 +27,8 @@ public class CustomRelation extends Relation implements FormattedQueryDomainObje
         this.mapping = Optional.empty();
     }
 
-    public void setMapping(RelationMapping mapping) throws UnrelatedMappingException {
+    public void setMapping(RelationMapping mapping, ConceptManager conceptManager)
+            throws UnrelatedMappingException {
         if (this.equals(mapping.getThenTriplet().getPredicate())) {
             this.mapping = Optional.of(mapping);
             Set<ActualObjectType> subjectRelatableTypes = new LinkedHashSet<>();
@@ -43,7 +45,7 @@ public class CustomRelation extends Relation implements FormattedQueryDomainObje
             mapping.getWhenTriplets()
                     .forEach(
                             andTriplets -> {
-                                variableManager.parseVariableTypes(andTriplets);
+                                variableManager.parseVariableTypes(andTriplets, conceptManager);
                                 subjectRelatableTypes.addAll(subject.getDynamicTypes());
                                 if (object instanceof Variable) {
                                     objectRelatableTypes.addAll(

--- a/web-ui/src/main/java/org/archcnl/domain/common/io/importhelper/MappingParser.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/io/importhelper/MappingParser.java
@@ -122,7 +122,8 @@ public class MappingParser {
                                         parseMapping(
                                                 potentialRelationMapping,
                                                 relationManager,
-                                                conceptManager));
+                                                conceptManager),
+                                        conceptManager);
                                 relations.add(relation);
                             } catch (UnrelatedMappingException
                                     | NoMappingException

--- a/web-ui/src/main/java/org/archcnl/domain/input/model/presets/microservicearchitecture/MicroserviceArchitectureTemplateManager.java
+++ b/web-ui/src/main/java/org/archcnl/domain/input/model/presets/microservicearchitecture/MicroserviceArchitectureTemplateManager.java
@@ -226,7 +226,7 @@ public class MicroserviceArchitectureTemplateManager implements ArchitecturalSty
                             TripletFactory.createTriplet(
                                     classVariable, registerinRelation, registryVariable),
                             whenTriplets);
-            registerinRelation.setMapping(mapping);
+            registerinRelation.setMapping(mapping, conceptManager);
             return registerinRelation;
         } catch (UnsupportedObjectTypeException | UnrelatedMappingException e) {
             // TODO Auto-generated catch block
@@ -455,7 +455,7 @@ public class MicroserviceArchitectureTemplateManager implements ArchitecturalSty
                     new RelationMapping(
                             TripletFactory.createTriplet(classVariable, haveown, class2Variable),
                             haveownWhenTriplets);
-            haveown.setMapping(mapping);
+            haveown.setMapping(mapping, conceptManager);
             return haveown;
         } catch (UnsupportedObjectTypeException | UnrelatedMappingException e) {
             // TODO Auto-generated catch block
@@ -829,7 +829,7 @@ public class MicroserviceArchitectureTemplateManager implements ArchitecturalSty
                     new RelationMapping(
                             TripletFactory.createTriplet(classVariable, useown, class2Variable),
                             useownWhenTriplets);
-            useown.setMapping(mapping);
+            useown.setMapping(mapping, conceptManager);
             return useown;
         } catch (UnsupportedObjectTypeException | UnrelatedMappingException e) {
             // TODO Auto-generated catch block
@@ -882,7 +882,7 @@ public class MicroserviceArchitectureTemplateManager implements ArchitecturalSty
                             TripletFactory.createTriplet(
                                     class2Package, resideInPackage, classPackage),
                             resideInWhenTriplets);
-            resideInPackage.setMapping(mapping);
+            resideInPackage.setMapping(mapping, conceptManager);
             return resideInPackage;
         } catch (UnsupportedObjectTypeException | UnrelatedMappingException e) {
             // TODO Auto-generated catch block
@@ -933,7 +933,7 @@ public class MicroserviceArchitectureTemplateManager implements ArchitecturalSty
                     new RelationMapping(
                             TripletFactory.createTriplet(classVariable, use, class2Variable),
                             useWhenTriplets);
-            use.setMapping(mapping);
+            use.setMapping(mapping, conceptManager);
             return use;
         } catch (UnsupportedObjectTypeException | UnrelatedMappingException e) {
             // TODO Auto-generated catch block

--- a/web-ui/src/main/java/org/archcnl/ui/MainPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/MainPresenter.java
@@ -20,6 +20,7 @@ import org.archcnl.ui.common.andtriplets.triplet.events.ConceptListUpdateRequest
 import org.archcnl.ui.common.andtriplets.triplet.events.ConceptSelectedEvent;
 import org.archcnl.ui.common.andtriplets.triplet.events.PredicateSelectedEvent;
 import org.archcnl.ui.common.andtriplets.triplet.events.RelationListUpdateRequestedEvent;
+import org.archcnl.ui.common.andtriplets.triplet.events.VariableSelectedEvent;
 import org.archcnl.ui.common.conceptandrelationlistview.HierarchyView;
 import org.archcnl.ui.common.conceptandrelationlistview.events.ConceptGridUpdateRequestedEvent;
 import org.archcnl.ui.common.conceptandrelationlistview.events.ConceptHierarchySwapRequestedEvent;
@@ -244,9 +245,11 @@ public class MainPresenter extends Component {
         inputPresenter.addListener(
                 ChangeRelationNameRequestedEvent.class, e -> e.handleEvent(relationManager));
         inputPresenter.addListener(
-                AddCustomRelationRequestedEvent.class, e -> e.handleEvent(relationManager));
+                AddCustomRelationRequestedEvent.class,
+                e -> e.handleEvent(relationManager, conceptManager));
         inputPresenter.addListener(
-                PredicateSelectedEvent.class, event -> event.handleEvent(relationManager));
+                PredicateSelectedEvent.class, e -> e.handleEvent(relationManager, conceptManager));
+        inputPresenter.addListener(VariableSelectedEvent.class, e -> e.handleEvent(conceptManager));
         inputPresenter.addListener(
                 RelationListUpdateRequestedEvent.class,
                 event -> event.handleEvent(relationManager.getInputRelations()));
@@ -269,7 +272,9 @@ public class MainPresenter extends Component {
                     view.setOpenProjectMenuItemEnabled(true);
                 });
         outputPresenter.addListener(
-                PredicateSelectedEvent.class, event -> event.handleEvent(relationManager));
+                PredicateSelectedEvent.class, e -> e.handleEvent(relationManager, conceptManager));
+        outputPresenter.addListener(
+                VariableSelectedEvent.class, e -> e.handleEvent(conceptManager));
         outputPresenter.addListener(
                 RelationListUpdateRequestedEvent.class,
                 event -> event.handleEvent(relationManager.getOutputRelations()));

--- a/web-ui/src/main/java/org/archcnl/ui/common/andtriplets/AndTripletsEditorPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/andtriplets/AndTripletsEditorPresenter.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.archcnl.domain.common.VariableManager;
 import org.archcnl.domain.common.conceptsandrelations.andtriplets.AndTriplets;
 import org.archcnl.domain.common.conceptsandrelations.andtriplets.triplet.Triplet;
 import org.archcnl.domain.common.conceptsandrelations.andtriplets.triplet.Variable;
@@ -100,10 +99,7 @@ public class AndTripletsEditorPresenter extends Component {
         view.addTripletView(prepareTripletView(new TripletPresenter()));
     }
 
-    private void showConflictingDynamicTypes() {
-        VariableManager variableManager = new VariableManager();
-        List<Variable> conflictingVariables =
-                variableManager.getConflictingVariables(getAndTriplets());
+    public void showConflictingDynamicTypes(List<Variable> conflictingVariables) {
         tripletPresenters.forEach(p -> p.highlightConflictingVariables(conflictingVariables));
     }
 
@@ -117,7 +113,11 @@ public class AndTripletsEditorPresenter extends Component {
         tripletPresenter.addListener(VariableCreationRequestedEvent.class, this::fireEvent);
         tripletPresenter.addListener(VariableListUpdateRequestedEvent.class, this::fireEvent);
         tripletPresenter.addListener(
-                VariableSelectedEvent.class, e -> showConflictingDynamicTypes());
+                VariableSelectedEvent.class,
+                e -> {
+                    e.setAndTripletsPresenter(this);
+                    fireEvent(e);
+                });
         tripletPresenter.addListener(
                 TripletViewDeleteButtonPressedEvent.class,
                 event -> deleteTripletView(event.getSource()));
@@ -128,7 +128,7 @@ public class AndTripletsEditorPresenter extends Component {
         tripletPresenter.addListener(
                 PredicateSelectedEvent.class,
                 e -> {
-                    showConflictingDynamicTypes();
+                    e.setAndTripletsPresenter(this);
                     fireEvent(e);
                 });
         tripletPresenter.addListener(RelationListUpdateRequestedEvent.class, this::fireEvent);

--- a/web-ui/src/main/java/org/archcnl/ui/common/andtriplets/triplet/events/PredicateSelectedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/andtriplets/triplet/events/PredicateSelectedEvent.java
@@ -1,9 +1,14 @@
 package org.archcnl.ui.common.andtriplets.triplet.events;
 
 import com.vaadin.flow.component.ComponentEvent;
+import java.util.List;
 import java.util.Optional;
+import org.archcnl.domain.common.ConceptManager;
 import org.archcnl.domain.common.RelationManager;
+import org.archcnl.domain.common.VariableManager;
 import org.archcnl.domain.common.conceptsandrelations.Relation;
+import org.archcnl.domain.common.conceptsandrelations.andtriplets.triplet.Variable;
+import org.archcnl.ui.common.andtriplets.AndTripletsEditorPresenter;
 import org.archcnl.ui.common.andtriplets.triplet.ObjectView;
 import org.archcnl.ui.common.andtriplets.triplet.PredicateSelectionComponent;
 
@@ -11,6 +16,7 @@ public class PredicateSelectedEvent extends ComponentEvent<PredicateSelectionCom
 
     private static final long serialVersionUID = 1L;
     private ObjectView objectView;
+    private AndTripletsEditorPresenter andTripletsPresenter;
 
     public PredicateSelectedEvent(
             final PredicateSelectionComponent source, final boolean fromClient) {
@@ -21,7 +27,18 @@ public class PredicateSelectedEvent extends ComponentEvent<PredicateSelectionCom
         this.objectView = objectView;
     }
 
-    public void handleEvent(final RelationManager relationManager) {
+    public void setAndTripletsPresenter(AndTripletsEditorPresenter andTripletsPresenter) {
+        this.andTripletsPresenter = andTripletsPresenter;
+    }
+
+    public void handleEvent(
+            final RelationManager relationManager, final ConceptManager conceptManager) {
+        VariableManager variableManager = new VariableManager();
+        List<Variable> conflictingVariables =
+                variableManager.getConflictingVariables(
+                        andTripletsPresenter.getAndTriplets(), conceptManager);
+        andTripletsPresenter.showConflictingDynamicTypes(conflictingVariables);
+
         final Optional<String> value = getSource().getSelectedItem();
         Optional<Relation> relation = Optional.empty();
         if (value.isPresent()) {

--- a/web-ui/src/main/java/org/archcnl/ui/common/andtriplets/triplet/events/VariableSelectedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/andtriplets/triplet/events/VariableSelectedEvent.java
@@ -1,13 +1,31 @@
 package org.archcnl.ui.common.andtriplets.triplet.events;
 
 import com.vaadin.flow.component.ComponentEvent;
+import java.util.List;
+import org.archcnl.domain.common.ConceptManager;
+import org.archcnl.domain.common.VariableManager;
+import org.archcnl.domain.common.conceptsandrelations.andtriplets.triplet.Variable;
+import org.archcnl.ui.common.andtriplets.AndTripletsEditorPresenter;
 import org.archcnl.ui.common.andtriplets.triplet.VariableSelectionComponent;
 
 public class VariableSelectedEvent extends ComponentEvent<VariableSelectionComponent> {
 
     private static final long serialVersionUID = -1969439375456440034L;
+    private AndTripletsEditorPresenter andTripletsPresenter;
 
     public VariableSelectedEvent(VariableSelectionComponent source, boolean fromClient) {
         super(source, fromClient);
+    }
+
+    public void setAndTripletsPresenter(AndTripletsEditorPresenter andTripletsPresenter) {
+        this.andTripletsPresenter = andTripletsPresenter;
+    }
+
+    public void handleEvent(final ConceptManager conceptManager) {
+        VariableManager variableManager = new VariableManager();
+        List<Variable> conflictingVariables =
+                variableManager.getConflictingVariables(
+                        andTripletsPresenter.getAndTriplets(), conceptManager);
+        andTripletsPresenter.showConflictingDynamicTypes(conflictingVariables);
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/InputPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/InputPresenter.java
@@ -14,6 +14,7 @@ import org.archcnl.ui.common.andtriplets.triplet.events.ConceptListUpdateRequest
 import org.archcnl.ui.common.andtriplets.triplet.events.ConceptSelectedEvent;
 import org.archcnl.ui.common.andtriplets.triplet.events.PredicateSelectedEvent;
 import org.archcnl.ui.common.andtriplets.triplet.events.RelationListUpdateRequestedEvent;
+import org.archcnl.ui.common.andtriplets.triplet.events.VariableSelectedEvent;
 import org.archcnl.ui.common.conceptandrelationlistview.events.ConceptEditorRequestedEvent;
 import org.archcnl.ui.common.conceptandrelationlistview.events.ConceptGridUpdateRequestedEvent;
 import org.archcnl.ui.common.conceptandrelationlistview.events.ConceptHierarchySwapRequestedEvent;
@@ -130,6 +131,7 @@ public class InputPresenter extends Component {
     private void addListenersToMappingEditor(MappingEditorPresenter presenter) {
         presenter.addListener(RulesWidgetRequestedEvent.class, this::handleEvent);
         presenter.addListener(PredicateSelectedEvent.class, this::fireEvent);
+        presenter.addListener(VariableSelectedEvent.class, this::fireEvent);
         presenter.addListener(RelationListUpdateRequestedEvent.class, this::fireEvent);
         presenter.addListener(ConceptListUpdateRequestedEvent.class, this::fireEvent);
         presenter.addListener(ConceptSelectedEvent.class, this::fireEvent);

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/MappingEditorPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/MappingEditorPresenter.java
@@ -25,6 +25,7 @@ import org.archcnl.ui.common.andtriplets.triplet.events.PredicateSelectedEvent;
 import org.archcnl.ui.common.andtriplets.triplet.events.RelationListUpdateRequestedEvent;
 import org.archcnl.ui.common.andtriplets.triplet.events.VariableCreationRequestedEvent;
 import org.archcnl.ui.common.andtriplets.triplet.events.VariableListUpdateRequestedEvent;
+import org.archcnl.ui.common.andtriplets.triplet.events.VariableSelectedEvent;
 import org.archcnl.ui.common.dialogs.ButtonClickResponder;
 import org.archcnl.ui.common.dialogs.OkCancelDialog;
 import org.archcnl.ui.inputview.rulesormappingeditorview.events.RulesWidgetRequestedEvent;
@@ -108,6 +109,7 @@ public abstract class MappingEditorPresenter extends Component {
                 VariableListUpdateRequestedEvent.class,
                 event -> event.handleEvent(variableManager));
 
+        andTripletsPresenter.addListener(VariableSelectedEvent.class, this::fireEvent);
         andTripletsPresenter.addListener(PredicateSelectedEvent.class, this::fireEvent);
         andTripletsPresenter.addListener(RelationListUpdateRequestedEvent.class, this::fireEvent);
         andTripletsPresenter.addListener(ConceptListUpdateRequestedEvent.class, this::fireEvent);

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/relationeditor/RelationEditorPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/relationeditor/RelationEditorPresenter.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import org.archcnl.domain.common.conceptsandrelations.CustomRelation;
 import org.archcnl.domain.common.conceptsandrelations.andtriplets.AndTriplets;
 import org.archcnl.domain.common.conceptsandrelations.andtriplets.triplet.Triplet;
-import org.archcnl.domain.common.exceptions.UnrelatedMappingException;
 import org.archcnl.domain.input.model.mappings.RelationMapping;
 import org.archcnl.ui.common.andtriplets.AndTripletsEditorPresenter;
 import org.archcnl.ui.common.andtriplets.triplet.events.VariableCreationRequestedEvent;
@@ -97,13 +96,8 @@ public class RelationEditorPresenter extends MappingEditorPresenter {
 
                 final RelationMapping mapping =
                         new RelationMapping(thenTriplet, getAndTripletsList());
-
-                relation.get().setMapping(mapping);
-                fireEvent(new AddCustomRelationRequestedEvent(this, true, relation.get()));
-
+                fireEvent(new AddCustomRelationRequestedEvent(this, true, relation.get(), mapping));
                 fireEvent(new RulesWidgetRequestedEvent(this, true));
-            } catch (UnrelatedMappingException e) {
-                throw new RuntimeException(e.getMessage());
             } catch (final SubjectOrObjectNotDefinedException e) {
                 view.showThenSubjectOrObjectErrorMessage("Setting this is required");
             }

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/relationeditor/events/AddCustomRelationRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/relationeditor/events/AddCustomRelationRequestedEvent.java
@@ -1,23 +1,36 @@
 package org.archcnl.ui.inputview.rulesormappingeditorview.mappingeditor.relationeditor.events;
 
 import com.vaadin.flow.component.ComponentEvent;
+import org.archcnl.domain.common.ConceptManager;
 import org.archcnl.domain.common.RelationManager;
 import org.archcnl.domain.common.conceptsandrelations.CustomRelation;
 import org.archcnl.domain.common.exceptions.RelationAlreadyExistsException;
+import org.archcnl.domain.common.exceptions.UnrelatedMappingException;
+import org.archcnl.domain.input.model.mappings.RelationMapping;
 import org.archcnl.ui.inputview.rulesormappingeditorview.mappingeditor.relationeditor.RelationEditorPresenter;
 
 public class AddCustomRelationRequestedEvent extends ComponentEvent<RelationEditorPresenter> {
 
     private static final long serialVersionUID = -937210551886454814L;
     private CustomRelation relation;
+    private RelationMapping mapping;
 
     public AddCustomRelationRequestedEvent(
-            RelationEditorPresenter source, boolean fromClient, CustomRelation relation) {
+            RelationEditorPresenter source,
+            boolean fromClient,
+            CustomRelation relation,
+            RelationMapping mapping) {
         super(source, fromClient);
         this.relation = relation;
+        this.mapping = mapping;
     }
 
-    public void handleEvent(RelationManager relationManager) {
+    public void handleEvent(RelationManager relationManager, ConceptManager conceptManager) {
+        try {
+            relation.setMapping(mapping, conceptManager);
+        } catch (UnrelatedMappingException e) {
+            throw new RuntimeException(e.getMessage());
+        }
         if (!relationManager.doesRelationExist(relation)) {
             try {
                 relationManager.addToParent(relation, "Custom Relations");

--- a/web-ui/src/main/java/org/archcnl/ui/outputview/OutputPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/outputview/OutputPresenter.java
@@ -19,6 +19,7 @@ import org.archcnl.ui.common.andtriplets.triplet.events.ConceptListUpdateRequest
 import org.archcnl.ui.common.andtriplets.triplet.events.ConceptSelectedEvent;
 import org.archcnl.ui.common.andtriplets.triplet.events.PredicateSelectedEvent;
 import org.archcnl.ui.common.andtriplets.triplet.events.RelationListUpdateRequestedEvent;
+import org.archcnl.ui.common.andtriplets.triplet.events.VariableSelectedEvent;
 import org.archcnl.ui.common.conceptandrelationlistview.events.ConceptGridUpdateRequestedEvent;
 import org.archcnl.ui.common.conceptandrelationlistview.events.ConceptHierarchySwapRequestedEvent;
 import org.archcnl.ui.common.conceptandrelationlistview.events.RelationGridUpdateRequestedEvent;
@@ -135,6 +136,7 @@ public class OutputPresenter extends Component {
         newCustomQueryPresenter.addListener(
                 RelationHierarchySwapRequestedEvent.class, this::fireEvent);
         newCustomQueryPresenter.addListener(PredicateSelectedEvent.class, this::fireEvent);
+        newCustomQueryPresenter.addListener(VariableSelectedEvent.class, this::fireEvent);
         newCustomQueryPresenter.addListener(
                 RelationListUpdateRequestedEvent.class, this::fireEvent);
         newCustomQueryPresenter.addListener(ConceptListUpdateRequestedEvent.class, this::fireEvent);

--- a/web-ui/src/main/java/org/archcnl/ui/outputview/queryviews/CustomQueryPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/outputview/queryviews/CustomQueryPresenter.java
@@ -93,6 +93,7 @@ public class CustomQueryPresenter extends Component {
                 VariableListUpdateRequestedEvent.class,
                 event -> event.handleEvent(variableManager));
         wherePresenter.addListener(PredicateSelectedEvent.class, this::fireEvent);
+        wherePresenter.addListener(VariableSelectedEvent.class, this::fireEvent);
         wherePresenter.addListener(RelationListUpdateRequestedEvent.class, this::fireEvent);
         wherePresenter.addListener(ConceptListUpdateRequestedEvent.class, this::fireEvent);
         wherePresenter.addListener(ConceptSelectedEvent.class, this::fireEvent);

--- a/web-ui/src/test/java/org/archcnl/domain/TestUtils.java
+++ b/web-ui/src/test/java/org/archcnl/domain/TestUtils.java
@@ -269,7 +269,7 @@ public class TestUtils {
                 new RelationMapping(
                         TripletFactory.createTriplet(classVariable, resideIn, packageVariable),
                         resideInWhenTriplets);
-        resideIn.setMapping(resideInMapping);
+        resideIn.setMapping(resideInMapping, conceptManager);
 
         final CustomRelation use =
                 new CustomRelation(
@@ -281,7 +281,7 @@ public class TestUtils {
                 new RelationMapping(
                         TripletFactory.createTriplet(classVariable, use, class2Variable),
                         useWhenTriplets);
-        use.setMapping(useMapping);
+        use.setMapping(useMapping, conceptManager);
 
         final CustomRelation emptyWhenRelationString =
                 new CustomRelation(
@@ -296,7 +296,7 @@ public class TestUtils {
                                 emptyWhenRelationString,
                                 new StringValue("test string")),
                         new LinkedList<>());
-        emptyWhenRelationString.setMapping(emptyWhenRelationStringMapping);
+        emptyWhenRelationString.setMapping(emptyWhenRelationStringMapping, conceptManager);
 
         final CustomRelation emptyWhenRelationBoolean =
                 new CustomRelation(
@@ -309,7 +309,7 @@ public class TestUtils {
                         TripletFactory.createTriplet(
                                 varVariable, emptyWhenRelationBoolean, new BooleanValue(false)),
                         new LinkedList<>());
-        emptyWhenRelationBoolean.setMapping(emptyWhenRelationBooleanMapping);
+        emptyWhenRelationBoolean.setMapping(emptyWhenRelationBooleanMapping, conceptManager);
 
         final CustomRelation emptyWhenRelationVariable =
                 new CustomRelation(
@@ -322,7 +322,7 @@ public class TestUtils {
                         TripletFactory.createTriplet(
                                 varVariable, emptyWhenRelationVariable, new Variable("test")),
                         new LinkedList<>());
-        emptyWhenRelationVariable.setMapping(emptyWhenRelationVariableMapping);
+        emptyWhenRelationVariable.setMapping(emptyWhenRelationVariableMapping, conceptManager);
 
         relationManager.addRelation(resideIn);
         relationManager.addRelation(use);

--- a/web-ui/src/test/java/org/archcnl/domain/common/RelationManagerTest.java
+++ b/web-ui/src/test/java/org/archcnl/domain/common/RelationManagerTest.java
@@ -409,7 +409,7 @@ class RelationManagerTest {
                         TripletFactory.createTriplet(
                                 new Variable("class"), withRelation, new Variable("x")),
                         when1);
-        withRelation.setMapping(mapping1);
+        withRelation.setMapping(mapping1, conceptManager);
         relationManager.addOrAppend(withRelation);
         Assertions.assertEquals(
                 inputRelationsCount + 3, relationManager.getInputRelations().size());
@@ -436,7 +436,7 @@ class RelationManagerTest {
                         TripletFactory.createTriplet(
                                 new Variable("class"), otherWithRelation, new Variable("x")),
                         when2);
-        otherWithRelation.setMapping(mapping2);
+        otherWithRelation.setMapping(mapping2, conceptManager);
         relationManager.addOrAppend(otherWithRelation);
         Assertions.assertEquals(
                 inputRelationsCount + 3, relationManager.getInputRelations().size());

--- a/web-ui/src/test/java/org/archcnl/domain/common/VariableManagerTest.java
+++ b/web-ui/src/test/java/org/archcnl/domain/common/VariableManagerTest.java
@@ -24,10 +24,12 @@ import org.junit.jupiter.api.Test;
 class VariableManagerTest {
 
     private VariableManager variableManager;
+    private ConceptManager conceptManager;
 
     @BeforeEach
     void setup() {
         variableManager = new VariableManager();
+        conceptManager = new ConceptManager();
     }
 
     @Test
@@ -43,7 +45,9 @@ class VariableManagerTest {
             Optional<ConceptMapping> mapping = concept.getMapping();
             if (mapping.isPresent()) {
                 for (AndTriplets andTriplets : mapping.get().getWhenTriplets()) {
-                    Assertions.assertFalse(variableManager.hasConflictingDynamicTypes(andTriplets));
+                    Assertions.assertFalse(
+                            variableManager.hasConflictingDynamicTypes(
+                                    andTriplets, conceptManager));
                 }
             }
         }
@@ -63,7 +67,9 @@ class VariableManagerTest {
             Optional<RelationMapping> mapping = relation.getMapping();
             if (mapping.isPresent()) {
                 for (AndTriplets andTriplets : mapping.get().getWhenTriplets()) {
-                    Assertions.assertFalse(variableManager.hasConflictingDynamicTypes(andTriplets));
+                    Assertions.assertFalse(
+                            variableManager.hasConflictingDynamicTypes(
+                                    andTriplets, conceptManager));
                 }
             }
         }
@@ -92,7 +98,8 @@ class VariableManagerTest {
         // when and then
         // this is a conflict as ?class is of type FamixClass after the first triplet
         // while the matches relation is only defined for string variables as subjects
-        Assertions.assertTrue(variableManager.hasConflictingDynamicTypes(andTriplets));
+        Assertions.assertTrue(
+                variableManager.hasConflictingDynamicTypes(andTriplets, conceptManager));
         Assertions.assertTrue(
                 variableManager
                         .getVariableByName(classVariable.getName())
@@ -125,7 +132,8 @@ class VariableManagerTest {
         // when and then
         // The matches relation is only defined for strings and string variables as object.
         // But in triplet3 the object variable has type FamixClass
-        Assertions.assertTrue(variableManager.hasConflictingDynamicTypes(andTriplets));
+        Assertions.assertTrue(
+                variableManager.hasConflictingDynamicTypes(andTriplets, conceptManager));
         Assertions.assertFalse(
                 variableManager
                         .getVariableByName(name.getName())
@@ -139,11 +147,7 @@ class VariableManagerTest {
     }
 
     @Test
-    /**
-     * This test shows the limitations of the current dynamicTypeChecker. It reports a type conflict
-     * for a valid AndTriplets.
-     */
-    void givenValidAndTriplets_whenCheckingDynamicTypes_thenIncorrectConflictDetected()
+    void givenValidAndTriplets_whenCheckingDynamicTypes_thenNoConflictDetected()
             throws ConceptDoesNotExistException, UnrelatedMappingException,
                     UnsupportedObjectTypeException, ConceptAlreadyExistsException {
         // given
@@ -162,19 +166,8 @@ class VariableManagerTest {
         AndTriplets andTriplets = new AndTriplets(Arrays.asList(triplet1, triplet2));
 
         // when and then
-        // Aggregate is a sub-class of FamixClass and thus hasName is defined on it.
-        // However, the current dynamicTypeChecker does not look recursively over CustomConcepts
-        // until it finds a DefaultConcept.
-        Assertions.assertTrue(variableManager.hasConflictingDynamicTypes(andTriplets));
-        Assertions.assertTrue(
-                variableManager
-                        .getVariableByName(aggregate.getName())
-                        .get()
-                        .hasConflictingDynamicTypes());
+        // Aggregate is a sub-class of FamixClass and thus hasName is also defined on it.
         Assertions.assertFalse(
-                variableManager
-                        .getVariableByName(name.getName())
-                        .get()
-                        .hasConflictingDynamicTypes());
+                variableManager.hasConflictingDynamicTypes(andTriplets, conceptManager));
     }
 }


### PR DESCRIPTION
This fixes a previous limitation of the type checker. See this example (Aggregate is one of the concepts from the OnionArchitectureDemo):

`(?a rdf:type architecture:Aggregate)
(?a famix:hasName ?name)`

Previously, these triplets would have resulted in a "Potential Type conflict" as hasName is defined on FamixClass and not on Aggregate. Now the type checker figures out that Aggregate is defined as a sub-type of FamixClass in its mapping and thus hasName is also defined for it. No type conflicts are reported in the GUI.