### PR TITLE
Missing NamedEntiy subject types added

### DIFF
--- a/web-ui/src/main/java/org/archcnl/domain/common/RelationManager.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/RelationManager.java
@@ -175,6 +175,10 @@ public class RelationManager extends HierarchyManager<Relation> {
         namedEntity.add(extractConcept(conceptManager, "AnnotationType"));
         namedEntity.add(extractConcept(conceptManager, "Enum"));
         namedEntity.add(extractConcept(conceptManager, "FamixClass"));
+        namedEntity.add(extractConcept(conceptManager, "Method"));
+        namedEntity.add(extractConcept(conceptManager, "Parameter"));
+        namedEntity.add(extractConcept(conceptManager, "LocalVariable"));
+        namedEntity.add(extractConcept(conceptManager, "Attribute"));
         addToDefault(
                 new FamixRelation(
                         "hasModifier",


### PR DESCRIPTION
I noticed that some very important concepts that are in fact part of NamedEntity in the ontology were missing from the list of allowed subject types. I suspect there might be quite a few more missing subject/object types in the GUI.