### PR TITLE
Remove no longer used classpathentries

### DIFF
--- a/org.architecture.cnl.parent/org.architecture.cnl/.classpath
+++ b/org.architecture.cnl.parent/org.architecture.cnl/.classpath
@@ -14,18 +14,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/xtend-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/xtext-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
@@ -37,17 +25,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>


### PR DESCRIPTION
All three have been empty for quite some time. Removing them also reduces class path warnings in Eclipse.
- The contents of src/test/xtend-gen have been moved to src/test/java [see comment in this file](https://github.com/Mari-Wie/ArchCNL/blob/master/org.architecture.cnl.parent/org.architecture.cnl/src/main/java/org/architecture/cnl/GenerateArchCnl.mwe2)
- src/main/resources and src/test/resources have not been used for at least a whole year