### PR TITLE
Reactive header of RuleWidget

### DIFF
--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyView.java
@@ -1,6 +1,8 @@
 package org.archcnl.ui.common.conceptandrelationlistview;
 
 import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Key;
@@ -10,6 +12,7 @@ import com.vaadin.flow.component.grid.dnd.GridDropMode;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
@@ -23,21 +26,24 @@ import org.archcnl.ui.common.conceptandrelationlistview.events.DeleteHierarchyOb
 import org.archcnl.ui.common.conceptandrelationlistview.events.GridUpdateRequestedEvent;
 import org.archcnl.ui.common.conceptandrelationlistview.events.HierarchySwapRequestedEvent;
 import org.archcnl.ui.common.conceptandrelationlistview.events.NodeAddRequestedEvent;
-import org.archcnl.ui.inputview.rulesormappingeditorview.RulesOrMappingEditorView;
 
-public class HierarchyView<T extends HierarchyObject> extends RulesOrMappingEditorView {
+public class HierarchyView<T extends HierarchyObject> extends VerticalLayout {
     private TreeGrid<HierarchyNode<T>> treeGrid;
-    List<HierarchyNode<T>> roots;
-    List<HierarchyNode<T>> expandedNodes;
+    private List<HierarchyNode<T>> roots;
+    private List<HierarchyNode<T>> expandedNodes;
     private HierarchyNode<T> draggedItem;
     // filter by name
-    TextField searchField = new TextField();
-    HorizontalLayout searchBar = new HorizontalLayout();
-    Button searchButton;
-    Button cancelButton;
+    private TextField searchField = new TextField();
+    private HorizontalLayout searchBar = new HorizontalLayout();
+    private Button searchButton;
+    private Button cancelButton;
+    protected HorizontalLayout footer = new HorizontalLayout();
+    protected Component addNodeElement;
+    protected Button addNode = new Button("No LABEL");
 
     public HierarchyView() {
         setClassName("hierarchy");
+        footer = new HorizontalLayout();
         roots = new ArrayList<HierarchyNode<T>>();
         expandedNodes = new ArrayList<HierarchyNode<T>>(roots);
         treeGrid = new TreeGrid<HierarchyNode<T>>();
@@ -86,6 +92,15 @@ public class HierarchyView<T extends HierarchyObject> extends RulesOrMappingEdit
                             replace(searchBar, footer);
                         });
         searchBar.add(searchField, cancelButton);
+    }
+
+    public HorizontalLayout createEditorButton(
+            String buttonLabel, ComponentEventListener<ClickEvent<Button>> clickListener) {
+
+        addNode = new Button(buttonLabel, clickListener);
+        addNodeElement = addNode;
+        footer.add(addNodeElement);
+        return footer;
     }
 
     public HierarchyEntryLayout createNewHierarchyEntry(HierarchyNode node) {

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/RulesOrMappingEditorView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/RulesOrMappingEditorView.java
@@ -1,29 +1,27 @@
 package org.archcnl.ui.inputview.rulesormappingeditorview;
 
 import com.vaadin.flow.component.ClickEvent;
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 
 public abstract class RulesOrMappingEditorView extends VerticalLayout {
 
     private static final long serialVersionUID = -8185825107846587765L;
-    protected HorizontalLayout footer = new HorizontalLayout();
-    protected Component addNodeElement;
-    protected Button addNode = new Button("No LABEL");
 
-    public RulesOrMappingEditorView() {
-        footer = new HorizontalLayout();
-    }
+    public HorizontalLayout createCreateNewLayout(
+            String label,
+            String buttonLabel,
+            ComponentEventListener<ClickEvent<Button>> clickListener) {
+        HorizontalLayout createNewLayout = new HorizontalLayout();
 
-    public HorizontalLayout createEditorButton(
-            String buttonLabel, ComponentEventListener<ClickEvent<Button>> clickListener) {
-
-        addNode = new Button(buttonLabel, clickListener);
-        addNodeElement = addNode;
-        footer.add(addNodeElement);
-        return footer;
+        final Label archRulesLabel = new Label(label);
+        final Button createNewRuleButton = new Button(buttonLabel, clickListener);
+        createNewLayout.add(archRulesLabel);
+        createNewLayout.add(createNewRuleButton);
+        add(createNewLayout);
+        return createNewLayout;
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/RulesWidget.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/architectureruleeditor/RulesWidget.java
@@ -19,9 +19,10 @@ public class RulesWidget extends RulesOrMappingEditorView {
 
     public RulesWidget() {
         setWidthFull();
-        // TODO: Separate ArchitectureRulesLayout from CreateNewLayout
-        createEditorButton(
-                "Create new Arch Rule", e -> fireEvent(new RuleCreatorRequestedEvent(this, true)));
+        createCreateNewLayout(
+                "Architecture Rules",
+                "Create new Arch Rule",
+                e -> fireEvent(new RuleCreatorRequestedEvent(this, true)));
         add(rulesLayout);
     }
 


### PR DESCRIPTION
In PR #313 the superclass of the RuleWidget (responsible for displaying the list of architecture rules and linking to the RuleCreatorView was changed in order to be reused in the HierarchyView. However, this change removed the header from the RulesWidget making it impossible to access the RuleCreatorView.

This PR does the following:
- Undo the changes to RulesOrMappingEditorView and RuleWidget in order to reactivate the header.
- Move the HierarchyView specific code introduced in #313 to the RulesOrMappingEditorView directly into HierarchyView. HierarchyView was never supposed to be a subclass of RulesOrMappingEditorView in the first place as the name suggests.