### PR TITLE
Fix warnings, small refactorings, and general cleanup

### DIFF
--- a/java-parser/src/main/java/org/archcnl/javaparser/visitors/DeclaredJavaTypeVisitor.java
+++ b/java-parser/src/main/java/org/archcnl/javaparser/visitors/DeclaredJavaTypeVisitor.java
@@ -19,8 +19,6 @@ public class DeclaredJavaTypeVisitor extends VoidVisitorAdapter<Void> {
 
     private Type type;
 
-    public DeclaredJavaTypeVisitor() {}
-
     @Override
     public void visit(ClassOrInterfaceType n, Void arg) {
 

--- a/owlify-famix/src/main/java/org/archcnl/owlify/famix/codemodel/LocalVariable.java
+++ b/owlify-famix/src/main/java/org/archcnl/owlify/famix/codemodel/LocalVariable.java
@@ -87,7 +87,7 @@ public class LocalVariable {
 
         String location = path.toString();
         if (beginning.isPresent()) {
-            location += ", Line: " + String.valueOf(beginning.get());
+            location += ", Line: " + beginning.get();
         }
         individual.addLiteral(ontology.get(isLocatedAt), location);
 

--- a/owlify-famix/src/main/java/org/archcnl/owlify/famix/ontology/DefinedTypeCache.java
+++ b/owlify-famix/src/main/java/org/archcnl/owlify/famix/ontology/DefinedTypeCache.java
@@ -13,15 +13,20 @@ public class DefinedTypeCache {
     }
 
     public void addDefinedType(String fullyQualifiedName, Individual typeIndividual) {
-
-        assert (!isDefined(fullyQualifiedName));
+        if (isDefined(fullyQualifiedName)) {
+            throw new IllegalArgumentException(
+                    "Type already present in DefinedTypeCache :" + fullyQualifiedName);
+        }
 
         types.put(fullyQualifiedName, typeIndividual);
     }
 
     public Individual getIndividual(String fullyQualifiedName) {
 
-        assert (isDefined(fullyQualifiedName));
+        if (!isDefined(fullyQualifiedName)) {
+            throw new IllegalArgumentException(
+                    "Type not present in DefinedTypeCache :" + fullyQualifiedName);
+        }
 
         return types.getOrDefault(fullyQualifiedName, null);
     }

--- a/owlify-famix/src/main/java/org/archcnl/owlify/famix/ontology/FamixOntology.java
+++ b/owlify-famix/src/main/java/org/archcnl/owlify/famix/ontology/FamixOntology.java
@@ -155,7 +155,6 @@ public class FamixOntology {
         definesAttribute,
         hasDeclaredType,
         definesMethod,
-        hasDefiningClass,
         hasDeclaredException,
         definesParameter,
         hasCaughtException,

--- a/owlify-famix/src/main/resources/ontologies/famix.owl
+++ b/owlify-famix/src/main/resources/ontologies/famix.owl
@@ -753,6 +753,11 @@
         <hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long</hasName>
     </owl:NamedIndividual>
 
+    <owl:NamedIndividual rdf:about="http://arch-ont.org/ontologies/famix.owl#short">
+        <rdf:type rdf:resource="http://arch-ont.org/ontologies/famix.owl#PrimitiveType"/>
+        <hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short</hasName>
+    </owl:NamedIndividual>
+
     <owl:NamedIndividual rdf:about="http://arch-ont.org/ontologies/famix.owl#boolean">
         <rdf:type rdf:resource="http://arch-ont.org/ontologies/famix.owl#PrimitiveType"/>
         <hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">boolean</hasName>

--- a/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogDatabase.java
+++ b/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogDatabase.java
@@ -1,6 +1,5 @@
 package org.archcnl.stardogwrapper.impl;
 
-import com.complexible.common.rdf.query.resultio.TextTableQueryResultWriter;
 import com.complexible.stardog.StardogException;
 import com.complexible.stardog.api.Connection;
 import com.complexible.stardog.api.ConnectionConfiguration;
@@ -15,12 +14,10 @@ import com.stardog.stark.Values;
 import com.stardog.stark.io.RDFFormats;
 import com.stardog.stark.query.BindingSet;
 import com.stardog.stark.query.SelectQueryResult;
-import com.stardog.stark.query.io.QueryResultWriters;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -35,20 +32,20 @@ public class StardogDatabase implements StardogDatabaseAPI {
 
     private static final Logger LOG = LogManager.getLogger(StardogDatabase.class);
 
-    private String _server;
-    private String _databaseName;
+    private String server;
+    private String databaseName;
 
-    private String _userName;
-    private String _password;
+    private String userName;
+    private String password;
 
     private ConnectionPool connectionPool;
     private Connection connection;
 
     public StardogDatabase(String server, String databaseName, String userName, String password) {
-        _server = server;
-        _databaseName = databaseName;
-        _userName = userName;
-        _password = password;
+        this.server = server;
+        this.databaseName = databaseName;
+        this.userName = userName;
+        this.password = password;
     }
 
     @Override
@@ -60,8 +57,8 @@ public class StardogDatabase implements StardogDatabaseAPI {
         }
 
         try (final AdminConnection aConn =
-                AdminConnectionConfiguration.toServer(_server)
-                        .credentials(_userName, _password)
+                AdminConnectionConfiguration.toServer(server)
+                        .credentials(userName, password)
                         .connect()) {
 
             if (deletePreviousDatabases) {
@@ -71,20 +68,20 @@ public class StardogDatabase implements StardogDatabaseAPI {
                 }
             }
 
-            if (!aConn.list().contains(_databaseName)) {
-                aConn.newDatabase(_databaseName).create();
-                LOG.info("New database created: " + _databaseName);
+            if (!aConn.list().contains(databaseName)) {
+                aConn.newDatabase(databaseName).create();
+                LOG.info("New database created: " + databaseName);
             } else {
-                LOG.warn("Database already exists: " + _databaseName);
+                LOG.warn("Database already exists: " + databaseName);
             }
         }
 
         LOG.debug("Start connection configuration ...");
         ConnectionConfiguration connectionConfig =
-                ConnectionConfiguration.to(_databaseName)
-                        .server(_server)
+                ConnectionConfiguration.to(databaseName)
+                        .server(server)
                         .reasoning(false)
-                        .credentials(_userName, _password);
+                        .credentials(userName, password);
         ConnectionPoolConfig poolConfig = ConnectionPoolConfig.using(connectionConfig);
         connectionPool = poolConfig.create();
         LOG.debug("ConnectionPool created.");
@@ -141,22 +138,22 @@ public class StardogDatabase implements StardogDatabaseAPI {
 
     @Override
     public String getServer() {
-        return _server;
+        return server;
     }
 
     @Override
     public String getDatabaseName() {
-        return _databaseName;
+        return databaseName;
     }
 
     @Override
     public String getUserName() {
-        return _userName;
+        return userName;
     }
 
     @Override
     public String getPassword() {
-        return _password;
+        return password;
     }
 
     @Override

--- a/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogDatabase.java
+++ b/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogDatabase.java
@@ -186,7 +186,7 @@ public class StardogDatabase implements StardogDatabaseAPI {
             List<String> variables = queryResults.variables();
             Result queryResult = new Result(variables);
 
-            Map<String, String> prefixMap = new HashMap<String, String>();
+            Map<String, String> prefixMap = new HashMap<>();
             connection
                     .namespaces()
                     .forEach(namespace -> prefixMap.put(namespace.prefix(), namespace.iri()));
@@ -216,8 +216,8 @@ public class StardogDatabase implements StardogDatabaseAPI {
     }
 
     private String stripPrefixes(String string, Map<String, String> namespaces) {
-        for (String prefix : namespaces.keySet()) {
-            string = string.replace(namespaces.get(prefix), prefix + ":");
+        for (Map.Entry<String, String> entry : namespaces.entrySet()) {
+            string = string.replace(entry.getValue(), entry.getKey() + ":");
         }
         return string;
     }

--- a/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogDatabase.java
+++ b/stardog-wrapper/src/main/java/org/archcnl/stardogwrapper/impl/StardogDatabase.java
@@ -222,22 +222,6 @@ public class StardogDatabase implements StardogDatabaseAPI {
         return string;
     }
 
-    private void printToConsole(SelectQueryResult results) {
-        try {
-            QueryResultWriters.write(results, System.out, TextTableQueryResultWriter.FORMAT);
-        } catch (IOException e) {
-            LOG.error("Failed to write results from query to Console");
-        }
-    }
-
-    private void selectQuery(String query) {
-        SelectQuery stardogSelectQuery = connection.select(query);
-        try (SelectQueryResult queryResults = stardogSelectQuery.execute()) {
-            System.out.println("The first ten results...");
-            printToConsole(queryResults);
-        }
-    }
-
     @Override
     public Optional<Result> executeSelectQuery(String query) {
         if (query.length() == 0) {

--- a/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
+++ b/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
@@ -55,7 +55,7 @@ public class CNLToolchain {
     private final Map<String, Supplier<OwlifyComponent>> transformerFactories =
             Map.ofEntries(
                     Map.entry("java", JavaOntologyTransformer::new),
-                    Map.entry("kotlin", KotlinOntologyTransformer::new));
+                    Map.entry("kotlin", KotlinOntologyTransformer::new),
                     Map.entry("git", GitOntologyTransformer::new));
 
     // private, use runToolchain to create and execute the toolchain

--- a/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
+++ b/toolchain/src/main/java/org/archcnl/toolchain/CNLToolchain.java
@@ -48,15 +48,15 @@ public class CNLToolchain {
     private final IConformanceCheck check;
     private final StardogDatabaseAPI db;
     private Map<ArchitectureRule, ConstraintViolationsResultSet> ruleToViolationMapping =
-            new HashMap<ArchitectureRule, ConstraintViolationsResultSet>();
+            new HashMap<>();
 
     // mapping of name to transformer factories
     // add new parsers here
     private final Map<String, Supplier<OwlifyComponent>> transformerFactories =
             Map.ofEntries(
-                    Map.entry("java", () -> new JavaOntologyTransformer()),
-                    Map.entry("kotlin", () -> new KotlinOntologyTransformer()),
-                    Map.entry("git", () -> new GitOntologyTransformer()));
+                    Map.entry("java", JavaOntologyTransformer::new),
+                    Map.entry("kotlin", KotlinOntologyTransformer::new));
+                    Map.entry("git", GitOntologyTransformer::new));
 
     // private, use runToolchain to create and execute the toolchain
     private CNLToolchain(
@@ -69,7 +69,7 @@ public class CNLToolchain {
         this.icvAPI = StardogAPIFactory.getICVAPI(db);
         this.transformers =
                 enabledTransformers.stream()
-                        .map(name -> createTransformer(name))
+                        .map(this::createTransformer)
                         .collect(Collectors.toList());
         this.check = new ConformanceCheckImpl();
     }
@@ -322,13 +322,9 @@ public class CNLToolchain {
     private Model buildCodeModel(List<Path> sourceCodePaths) {
         LOG.info("Creating the code model ...");
         LOG.info("Starting famix transformation ...");
-        var model =
-                transformers.stream()
-                        .map(transformer -> transformer.transform(sourceCodePaths))
-                        .reduce(
-                                null,
-                                (modelA, modelB) -> modelA == null ? modelB : modelA.union(modelB));
-        return model;
+        return transformers.stream()
+                .map(transformer -> transformer.transform(sourceCodePaths))
+                .reduce(null, (modelA, modelB) -> modelA == null ? modelB : modelA.union(modelB));
     }
 
     private List<ArchitectureRule> parseRuleFile(Path docPath) throws IOException {

--- a/web-ui/src/main/java/org/archcnl/domain/common/ConceptManager.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/ConceptManager.java
@@ -1,8 +1,9 @@
 package org.archcnl.domain.common;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.archcnl.domain.common.conceptsandrelations.Concept;
@@ -15,11 +16,10 @@ import org.archcnl.domain.input.model.mappings.ConceptMapping;
 
 public class ConceptManager extends HierarchyManager<Concept> {
 
-    private TreeMap<String, Concept> concepts;
+    private Map<String, Concept> concepts;
 
     public ConceptManager() {
-        super();
-        concepts = new TreeMap<>();
+        concepts = new HashMap<>();
         // TODO: move this to somewhere where to ConceptManager is created and files are loaded,
         // also
         // this has to be in something like: create empty project
@@ -30,17 +30,11 @@ public class ConceptManager extends HierarchyManager<Concept> {
     }
 
     public void addConcept(Concept concept) throws ConceptAlreadyExistsException {
-        if (!doesConceptExist(concept)) {
+        if (!doesConceptExist(concept.getName())) {
             concepts.put(concept.getName(), concept);
         } else {
             throw new ConceptAlreadyExistsException(concept.getName());
         }
-    }
-
-    public void addToParent(Concept concept, HierarchyNode<Concept> parent)
-            throws ConceptAlreadyExistsException {
-        addConcept(concept);
-        parent.add(concept);
     }
 
     public void addToParent(Concept concept, String parentName)
@@ -70,7 +64,7 @@ public class ConceptManager extends HierarchyManager<Concept> {
 
     public void addOrAppend(CustomConcept concept) throws UnrelatedMappingException {
         try {
-            if (!doesConceptExist(concept)) {
+            if (!doesConceptExist(concept.getName())) {
                 addToParent(concept, "Custom Concepts");
             } else {
                 append(concept);
@@ -88,8 +82,20 @@ public class ConceptManager extends HierarchyManager<Concept> {
         return Optional.ofNullable(concepts.get(name));
     }
 
-    public boolean doesConceptExist(Concept concept) {
-        return concepts.containsValue(concept);
+    public boolean doesConceptExist(String name) {
+        return concepts.containsKey(name);
+    }
+
+    public void updateName(String oldName, String newName) throws ConceptAlreadyExistsException {
+        if (!concepts.containsKey(oldName)) {
+            return;
+        }
+        if (doesConceptExist(newName) && !oldName.equals(newName)) {
+            throw new ConceptAlreadyExistsException(newName);
+        }
+        Concept concept = concepts.remove(oldName);
+        concept.changeName(newName);
+        concepts.put(newName, concept);
     }
 
     public void removeConcept(Concept concept) {

--- a/web-ui/src/main/java/org/archcnl/domain/common/ConceptManager.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/ConceptManager.java
@@ -47,9 +47,7 @@ public class ConceptManager extends HierarchyManager<Concept> {
             throws ConceptAlreadyExistsException {
         addConcept(concept);
         Optional<HierarchyNode<Concept>> parent =
-                hierarchy_roots.stream()
-                        .filter(node -> parentName.equals(node.getName()))
-                        .findAny();
+                hierarchyRoots.stream().filter(node -> parentName.equals(node.getName())).findAny();
         if (!parent.isPresent()) {
             // TODO: error handling
         }

--- a/web-ui/src/main/java/org/archcnl/domain/common/ConceptManager.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/ConceptManager.java
@@ -105,7 +105,7 @@ public class ConceptManager extends HierarchyManager<Concept> {
         removeFromHierarchy(new HierarchyNode<>(concept));
     }
 
-    public void removeNode(HierarchyNode node) {
+    public void removeNode(HierarchyNode<Concept> node) {
         if (node.hasEntry()) {
             concepts.remove(node.getName());
         }

--- a/web-ui/src/main/java/org/archcnl/domain/common/HierarchyManager.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/HierarchyManager.java
@@ -6,28 +6,28 @@ import org.archcnl.domain.common.conceptsandrelations.HierarchyObject;
 
 public class HierarchyManager<T extends HierarchyObject> {
 
-    List<HierarchyNode<T>> hierarchy_roots;
+    List<HierarchyNode<T>> hierarchyRoots;
 
     public HierarchyManager() {
-        hierarchy_roots = new ArrayList<HierarchyNode<T>>();
+        hierarchyRoots = new ArrayList<>();
     }
 
     public void addHierarchyRoot(String name) {
-        hierarchy_roots.add(new HierarchyNode<T>(name));
+        hierarchyRoots.add(new HierarchyNode<>(name));
     }
 
     public void addHierarchyRoot(String name, boolean removable) {
-        HierarchyNode newNode = new HierarchyNode<T>(name);
+        HierarchyNode<T> newNode = new HierarchyNode<>(name);
         newNode.setRemoveable(removable);
-        hierarchy_roots.add(newNode);
+        hierarchyRoots.add(newNode);
     }
 
     public void addHierarchyRoot(HierarchyNode<T> newRoot) {
-        hierarchy_roots.add(newRoot);
+        hierarchyRoots.add(newRoot);
     }
 
     private boolean containedInRoots(HierarchyNode<T> node) {
-        for (HierarchyNode<T> n : hierarchy_roots) {
+        for (HierarchyNode<T> n : hierarchyRoots) {
             if (node.equals(n)) {
                 return true;
             }
@@ -52,14 +52,14 @@ public class HierarchyManager<T extends HierarchyObject> {
     }
 
     public List<HierarchyNode<T>> getRoots() {
-        return hierarchy_roots;
+        return hierarchyRoots;
     }
 
     public boolean removeFromHierarchy(HierarchyNode<T> node) {
-        for (HierarchyNode<T> hn : hierarchy_roots) {
+        for (HierarchyNode<T> hn : hierarchyRoots) {
             if (hn.equals(node)) {
                 if (hn.isRemoveable()) {
-                    hierarchy_roots.remove(node);
+                    hierarchyRoots.remove(node);
                     return true;
                 } else {
                     return false;

--- a/web-ui/src/main/java/org/archcnl/domain/common/HierarchyNode.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/HierarchyNode.java
@@ -124,19 +124,21 @@ public class HierarchyNode<T extends HierarchyObject> {
      * @return true if node was added, false otherwise
      */
     public boolean add(HierarchyNode<T> newChild, String destination) {
-        if (getName() == destination) {
+        if (getName().equals(destination)) {
             return addChild(newChild);
         } else {
             for (HierarchyNode<T> node : children) {
-                return add(newChild, destination);
+                if (add(node, destination)) {
+                    return true;
+                }
             }
         }
         return false;
     }
 
     /**
-     * Removes given HierarchyNode Recursivelty searches in all children for given node If no node
-     * is found nothing changes in the hierarchy
+     * Removes given HierarchyNode Recursively searches in all children for given node If no node is
+     * found nothing changes in the hierarchy
      *
      * @param hierarchyNode The node that is to be removed
      * @return true if node was removed, false otherwise

--- a/web-ui/src/main/java/org/archcnl/domain/common/RelationManager.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/RelationManager.java
@@ -66,9 +66,7 @@ public class RelationManager extends HierarchyManager<Relation> {
             throws RelationAlreadyExistsException {
         addRelation(relation);
         Optional<HierarchyNode<Relation>> parent =
-                hierarchy_roots.stream()
-                        .filter(node -> parentName.equals(node.getName()))
-                        .findAny();
+                hierarchyRoots.stream().filter(node -> parentName.equals(node.getName())).findAny();
         if (!parent.isPresent()) {
             // TODO: error handling
         }

--- a/web-ui/src/main/java/org/archcnl/domain/common/RelationManager.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/RelationManager.java
@@ -146,7 +146,7 @@ public class RelationManager extends HierarchyManager<Relation> {
         removeFromHierarchy(new HierarchyNode<>(relation));
     }
 
-    public void removeNode(HierarchyNode node) {
+    public void removeNode(HierarchyNode<Relation> node) {
         if (node.hasEntry()) {
             relations.remove(node.getName());
         }

--- a/web-ui/src/main/java/org/archcnl/domain/common/conceptsandrelations/Concept.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/conceptsandrelations/Concept.java
@@ -1,9 +1,7 @@
 package org.archcnl.domain.common.conceptsandrelations;
 
 import java.util.Objects;
-import org.archcnl.domain.common.ConceptManager;
 import org.archcnl.domain.common.conceptsandrelations.andtriplets.triplet.ActualObjectType;
-import org.archcnl.domain.common.exceptions.ConceptAlreadyExistsException;
 
 public abstract class Concept extends ActualObjectType implements HierarchyObject {
 
@@ -34,13 +32,8 @@ public abstract class Concept extends ActualObjectType implements HierarchyObjec
         return Objects.hash(name);
     }
 
-    public void changeName(String newName, ConceptManager conceptManager)
-            throws ConceptAlreadyExistsException {
-        if (!conceptManager.doesConceptExist(new CustomConcept(newName, ""))) {
-            this.name = newName;
-        } else {
-            throw new ConceptAlreadyExistsException(newName);
-        }
+    public void changeName(String newName) {
+        name = newName;
     }
 
     @Override

--- a/web-ui/src/main/java/org/archcnl/domain/common/conceptsandrelations/Relation.java
+++ b/web-ui/src/main/java/org/archcnl/domain/common/conceptsandrelations/Relation.java
@@ -4,11 +4,9 @@ import java.util.Objects;
 import java.util.Set;
 import org.archcnl.domain.common.FormattedAdocDomainObject;
 import org.archcnl.domain.common.FormattedViewDomainObject;
-import org.archcnl.domain.common.RelationManager;
 import org.archcnl.domain.common.conceptsandrelations.andtriplets.triplet.ActualObjectType;
 import org.archcnl.domain.common.conceptsandrelations.andtriplets.triplet.ObjectType;
 import org.archcnl.domain.common.conceptsandrelations.andtriplets.triplet.Variable;
-import org.archcnl.domain.common.exceptions.RelationAlreadyExistsException;
 
 public abstract class Relation
         implements HierarchyObject, FormattedAdocDomainObject, FormattedViewDomainObject {
@@ -80,13 +78,8 @@ public abstract class Relation
         return Objects.hash(name);
     }
 
-    public void changeName(String newName, RelationManager relationManager)
-            throws RelationAlreadyExistsException {
-        if (relationManager.getRelationByName(newName).isEmpty()) {
-            this.name = newName;
-        } else {
-            throw new RelationAlreadyExistsException(newName);
-        }
+    public void changeName(String newName) {
+        name = newName;
     }
 
     @Override

--- a/web-ui/src/main/java/org/archcnl/ui/MainPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/MainPresenter.java
@@ -10,9 +10,10 @@ import org.apache.logging.log4j.Logger;
 import org.archcnl.application.exceptions.PropertyNotFoundException;
 import org.archcnl.domain.common.ArchitectureCheck;
 import org.archcnl.domain.common.ConceptManager;
-import org.archcnl.domain.common.HierarchyManager;
 import org.archcnl.domain.common.ProjectManager;
 import org.archcnl.domain.common.RelationManager;
+import org.archcnl.domain.common.conceptsandrelations.Concept;
+import org.archcnl.domain.common.conceptsandrelations.Relation;
 import org.archcnl.domain.common.exceptions.ConceptDoesNotExistException;
 import org.archcnl.domain.input.model.architecturerules.ArchitectureRule;
 import org.archcnl.domain.input.model.architecturerules.ArchitectureRuleManager;
@@ -79,8 +80,13 @@ public class MainPresenter extends Component {
         addOutputListeners();
     }
 
-    private void updateHierarchies(HierarchyManager hierarchyManager, HierarchyView hv) {
-        hv.setRoots(hierarchyManager.getRoots());
+    private void updateHierarchies(ConceptManager conceptManager, HierarchyView<Concept> hv) {
+        hv.setRoots(conceptManager.getRoots());
+        hv.update();
+    }
+
+    private void updateHierarchies(RelationManager relationManager, HierarchyView<Relation> hv) {
+        hv.setRoots(relationManager.getRoots());
         hv.update();
     }
 
@@ -156,11 +162,11 @@ public class MainPresenter extends Component {
         boolean removable = true;
         if (e.nodeType() == NodeAddRequestedEvent.NodeType.CONCEPT) {
             conceptManager.addHierarchyRoot(e.getName(), removable);
-            updateHierarchies(conceptManager, e.getSource());
+            updateHierarchies(conceptManager, (HierarchyView<Concept>) e.getSource());
         }
         if (e.nodeType() == NodeAddRequestedEvent.NodeType.RELATION) {
             relationManager.addHierarchyRoot(e.getName(), removable);
-            updateHierarchies(relationManager, e.getSource());
+            updateHierarchies(relationManager, (HierarchyView<Relation>) e.getSource());
         }
     }
 
@@ -170,12 +176,12 @@ public class MainPresenter extends Component {
     }
 
     private void handleEvent(final DeleteConceptRequestedEvent event) {
-        conceptManager.removeNode(event.getConcept());
+        conceptManager.removeNode(event.getHierarchyNode());
         updateHierarchies(conceptManager, event.getSource());
     }
 
     private void handleEvent(final DeleteRelationRequestedEvent event) {
-        relationManager.removeNode(event.getRelation());
+        relationManager.removeNode(event.getHierarchyNode());
         updateHierarchies(relationManager, event.getSource());
     }
 

--- a/web-ui/src/main/java/org/archcnl/ui/common/andtriplets/triplet/SelectionComponent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/andtriplets/triplet/SelectionComponent.java
@@ -10,8 +10,9 @@ import java.util.List;
 import org.archcnl.domain.common.HierarchyNode;
 
 public class SelectionComponent extends ComboBox<String> implements DropTarget<SelectionComponent> {
+
+    private static final long serialVersionUID = 5467026470229011239L;
     private String name;
-    private String type;
 
     public SelectionComponent(String placeholder) {
         name = placeholder;
@@ -24,8 +25,6 @@ public class SelectionComponent extends ComboBox<String> implements DropTarget<S
     }
 
     protected void handleDropEvent(Object data) {
-        // TODO: find a way to only handle events where the type is Hierarchynode to get rid of the
-        // instanceof
         String droppedName = "";
         if (data instanceof List) {
             List<HierarchyNode> nodes = (List<HierarchyNode>) data;
@@ -49,7 +48,7 @@ public class SelectionComponent extends ComboBox<String> implements DropTarget<S
     }
 
     public String getName() {
-        return new String(name);
+        return name;
     }
 
     public void highlightWhenEmpty() {

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/ConceptAndRelationView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/ConceptAndRelationView.java
@@ -36,10 +36,10 @@ public class ConceptAndRelationView extends VerticalLayout {
         createConceptHierarchy();
         createRelationHierarchy();
         addElements();
-        addNodeButton();
+        addFolderButton();
     }
 
-    private void addNodeButton() {
+    private void addFolderButton() {
         conceptHierarchyView.createEditorButton(
                 "New Folder", e -> conceptHierarchyView.addTextField());
         relationHierarchyView.createEditorButton(
@@ -58,7 +58,7 @@ public class ConceptAndRelationView extends VerticalLayout {
         conceptHierarchyView.addListener(
                 GridUpdateRequestedEvent.class, e -> requestConceptGridUpdate());
         conceptHierarchyView.addListener(
-                HierarchySwapRequestedEvent.class, this::requestConceptSwap);
+                HierarchySwapRequestedEvent.class, e -> fireEvent(new ConceptHierarchySwapRequestedEvent(e)));
         conceptHierarchyView.addListener(
                 NodeAddRequestedEvent.class,
                 e -> {
@@ -92,7 +92,7 @@ public class ConceptAndRelationView extends VerticalLayout {
         relationHierarchyView.addListener(
                 GridUpdateRequestedEvent.class, e -> requestRelationGridUpdate());
         relationHierarchyView.addListener(
-                HierarchySwapRequestedEvent.class, this::requestRelationSwap);
+                HierarchySwapRequestedEvent.class, e -> fireEvent(new RelationHierarchySwapRequestedEvent(e)));
 
         relationHierarchyView.addListener(
                 NodeAddRequestedEvent.class,
@@ -127,14 +127,6 @@ public class ConceptAndRelationView extends VerticalLayout {
 
     protected void requestRelationGridUpdate() {
         fireEvent(new RelationGridUpdateRequestedEvent(relationHierarchyView, true));
-    }
-
-    protected void requestConceptSwap(HierarchySwapRequestedEvent<Concept> e) {
-        fireEvent(new ConceptHierarchySwapRequestedEvent(e));
-    }
-
-    protected void requestRelationSwap(HierarchySwapRequestedEvent<Relation> e) {
-        fireEvent(new RelationHierarchySwapRequestedEvent(e));
     }
 
     @Override

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/ConceptAndRelationView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/ConceptAndRelationView.java
@@ -58,7 +58,7 @@ public class ConceptAndRelationView extends VerticalLayout {
         conceptHierarchyView.addListener(
                 GridUpdateRequestedEvent.class, e -> requestConceptGridUpdate());
         conceptHierarchyView.addListener(
-                HierarchySwapRequestedEvent.class, e -> fireEvent(new ConceptHierarchySwapRequestedEvent(e)));
+                HierarchySwapRequestedEvent.class, this::requestConceptSwap);
         conceptHierarchyView.addListener(
                 NodeAddRequestedEvent.class,
                 e -> {
@@ -92,7 +92,7 @@ public class ConceptAndRelationView extends VerticalLayout {
         relationHierarchyView.addListener(
                 GridUpdateRequestedEvent.class, e -> requestRelationGridUpdate());
         relationHierarchyView.addListener(
-                HierarchySwapRequestedEvent.class, e -> fireEvent(new RelationHierarchySwapRequestedEvent(e)));
+                HierarchySwapRequestedEvent.class, this::requestRelationSwap);
 
         relationHierarchyView.addListener(
                 NodeAddRequestedEvent.class,
@@ -127,6 +127,14 @@ public class ConceptAndRelationView extends VerticalLayout {
 
     protected void requestRelationGridUpdate() {
         fireEvent(new RelationGridUpdateRequestedEvent(relationHierarchyView, true));
+    }
+
+    protected void requestConceptSwap(HierarchySwapRequestedEvent e) {
+        fireEvent(new ConceptHierarchySwapRequestedEvent(e));
+    }
+
+    protected void requestRelationSwap(HierarchySwapRequestedEvent e) {
+        fireEvent(new RelationHierarchySwapRequestedEvent(e));
     }
 
     @Override

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/ConceptAndRelationView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/ConceptAndRelationView.java
@@ -41,9 +41,9 @@ public class ConceptAndRelationView extends VerticalLayout {
 
     private void addNodeButton() {
         conceptHierarchyView.createEditorButton(
-                "Add Node", e -> conceptHierarchyView.addTextField());
+                "New Folder", e -> conceptHierarchyView.addTextField());
         relationHierarchyView.createEditorButton(
-                "Add Node", e -> relationHierarchyView.addTextField());
+                "New Folder", e -> relationHierarchyView.addTextField());
     }
 
     // Overriden in the editable version of this

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/ConceptAndRelationView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/ConceptAndRelationView.java
@@ -26,7 +26,6 @@ import org.archcnl.ui.common.conceptandrelationlistview.events.RelationHierarchy
 public class ConceptAndRelationView extends VerticalLayout {
 
     private static final long serialVersionUID = 1L;
-    private static final int DEFAULT_EXPANSION_DEPTH = 10;
 
     protected HierarchyView<Concept> conceptHierarchyView;
     protected HierarchyView<Relation> relationHierarchyView;
@@ -42,15 +41,9 @@ public class ConceptAndRelationView extends VerticalLayout {
 
     private void addNodeButton() {
         conceptHierarchyView.createEditorButton(
-                "Add Node",
-                e -> {
-                    conceptHierarchyView.addTextField();
-                });
+                "Add Node", e -> conceptHierarchyView.addTextField());
         relationHierarchyView.createEditorButton(
-                "Add Node",
-                e -> {
-                    relationHierarchyView.addTextField();
-                });
+                "Add Node", e -> relationHierarchyView.addTextField());
     }
 
     // Overriden in the editable version of this
@@ -63,10 +56,7 @@ public class ConceptAndRelationView extends VerticalLayout {
         conceptHierarchyView.setHeight(50, Unit.PERCENTAGE);
 
         conceptHierarchyView.addListener(
-                GridUpdateRequestedEvent.class,
-                e -> {
-                    requestConceptGridUpdate();
-                });
+                GridUpdateRequestedEvent.class, e -> requestConceptGridUpdate());
         conceptHierarchyView.addListener(
                 HierarchySwapRequestedEvent.class, this::requestConceptSwap);
         conceptHierarchyView.addListener(
@@ -89,7 +79,7 @@ public class ConceptAndRelationView extends VerticalLayout {
                 event ->
                         fireEvent(
                                 new DeleteConceptRequestedEvent(
-                                        conceptHierarchyView, true, event.getHierarchyObject())));
+                                        conceptHierarchyView, true, event.getHierarchyNode())));
     }
 
     protected void initHierarchies() {
@@ -123,7 +113,7 @@ public class ConceptAndRelationView extends VerticalLayout {
                 event ->
                         fireEvent(
                                 new DeleteRelationRequestedEvent(
-                                        relationHierarchyView, true, event.getHierarchyObject())));
+                                        relationHierarchyView, true, event.getHierarchyNode())));
     }
 
     public void update() {
@@ -139,11 +129,11 @@ public class ConceptAndRelationView extends VerticalLayout {
         fireEvent(new RelationGridUpdateRequestedEvent(relationHierarchyView, true));
     }
 
-    protected void requestConceptSwap(HierarchySwapRequestedEvent e) {
+    protected void requestConceptSwap(HierarchySwapRequestedEvent<Concept> e) {
         fireEvent(new ConceptHierarchySwapRequestedEvent(e));
     }
 
-    protected void requestRelationSwap(HierarchySwapRequestedEvent e) {
+    protected void requestRelationSwap(HierarchySwapRequestedEvent<Relation> e) {
         fireEvent(new RelationHierarchySwapRequestedEvent(e));
     }
 

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/EditableConceptAndRelationView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/EditableConceptAndRelationView.java
@@ -6,9 +6,8 @@ import org.archcnl.ui.common.conceptandrelationlistview.events.ConceptEditorRequ
 import org.archcnl.ui.common.conceptandrelationlistview.events.RelationEditorRequestedEvent;
 
 public class EditableConceptAndRelationView extends ConceptAndRelationView {
-    public EditableConceptAndRelationView() {
-        super();
-    }
+
+    private static final long serialVersionUID = 2967841151192415193L;
 
     @Override
     protected void addElements() {

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/EditableHierarchyView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/EditableHierarchyView.java
@@ -10,9 +10,9 @@ public class EditableHierarchyView<T extends HierarchyObject> extends HierarchyV
     private static final long serialVersionUID = 4409737601179383368L;
 
     @Override
-    public HierarchyEntryLayout<T> createNewHierarchyEntry(HierarchyNode<T> node) {
+    public HierarchyEntryLayout createNewHierarchyEntry(HierarchyNode node) {
         HierarchyEntryLayout<T> newLayout;
-        HierarchyEntryLayoutFactory<T> factory = new HierarchyEntryLayoutFactory<>();
+        HierarchyEntryLayoutFactory factory = new HierarchyEntryLayoutFactory<>();
         if (node.hasEntry() && node.getEntry().isEditable()) {
             newLayout = factory.createEditable(node);
             newLayout.addListener(DeleteHierarchyObjectRequestedEvent.class, this::fireEvent);

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/EditableHierarchyView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/EditableHierarchyView.java
@@ -5,15 +5,14 @@ import org.archcnl.domain.common.conceptsandrelations.HierarchyObject;
 import org.archcnl.ui.common.conceptandrelationlistview.events.DeleteHierarchyObjectRequestedEvent;
 import org.archcnl.ui.common.conceptandrelationlistview.events.EditorRequestedEvent;
 
-public class EditableHierarchyView<T extends HierarchyObject> extends HierarchyView {
-    public EditableHierarchyView() {
-        super();
-    }
+public class EditableHierarchyView<T extends HierarchyObject> extends HierarchyView<T> {
+
+    private static final long serialVersionUID = 4409737601179383368L;
 
     @Override
-    public HierarchyEntryLayout createNewHierarchyEntry(HierarchyNode node) {
+    public HierarchyEntryLayout<T> createNewHierarchyEntry(HierarchyNode<T> node) {
         HierarchyEntryLayout<T> newLayout;
-        HierarchyEntryLayoutFactory factory = new HierarchyEntryLayoutFactory<T>();
+        HierarchyEntryLayoutFactory<T> factory = new HierarchyEntryLayoutFactory<T>();
         if (node.hasEntry() && node.getEntry().isEditable()) {
             newLayout = factory.createEditable(node);
             newLayout.addListener(DeleteHierarchyObjectRequestedEvent.class, this::fireEvent);

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/EditableHierarchyView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/EditableHierarchyView.java
@@ -12,7 +12,7 @@ public class EditableHierarchyView<T extends HierarchyObject> extends HierarchyV
     @Override
     public HierarchyEntryLayout<T> createNewHierarchyEntry(HierarchyNode<T> node) {
         HierarchyEntryLayout<T> newLayout;
-        HierarchyEntryLayoutFactory<T> factory = new HierarchyEntryLayoutFactory<T>();
+        HierarchyEntryLayoutFactory<T> factory = new HierarchyEntryLayoutFactory<>();
         if (node.hasEntry() && node.getEntry().isEditable()) {
             newLayout = factory.createEditable(node);
             newLayout.addListener(DeleteHierarchyObjectRequestedEvent.class, this::fireEvent);

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyEntryLayout.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyEntryLayout.java
@@ -38,7 +38,7 @@ public class HierarchyEntryLayout<T extends HierarchyObject> extends HorizontalL
     }
 
     public void handleDeleteEvent() {
-        fireEvent(new DeleteHierarchyObjectRequestedEvent<T>(this, true, entry));
+        fireEvent(new DeleteHierarchyObjectRequestedEvent(this, true, entry));
     }
 
     public void handleEditorRequestEvent() {

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyEntryLayout.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyEntryLayout.java
@@ -37,8 +37,8 @@ public class HierarchyEntryLayout<T extends HierarchyObject> extends HorizontalL
         getElement().setAttribute("title", entry.getDescription());
     }
 
-    public void handleDelteEvent() {
-        fireEvent(new DeleteHierarchyObjectRequestedEvent(this, true, entry));
+    public void handleDeleteEvent() {
+        fireEvent(new DeleteHierarchyObjectRequestedEvent<T>(this, true, entry));
     }
 
     public void handleEditorRequestEvent() {
@@ -46,8 +46,8 @@ public class HierarchyEntryLayout<T extends HierarchyObject> extends HorizontalL
     }
 
     @Override
-    public <T extends ComponentEvent<?>> Registration addListener(
-            final Class<T> eventType, final ComponentEventListener<T> listener) {
+    public <E extends ComponentEvent<?>> Registration addListener(
+            final Class<E> eventType, final ComponentEventListener<E> listener) {
         return getEventBus().addListener(eventType, listener);
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyEntryLayoutFactory.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyEntryLayoutFactory.java
@@ -7,22 +7,16 @@ import org.archcnl.domain.common.HierarchyNode;
 import org.archcnl.domain.common.conceptsandrelations.HierarchyObject;
 
 public class HierarchyEntryLayoutFactory<T extends HierarchyObject> {
-    public HierarchyEntryLayoutFactory() {}
 
     public HierarchyEntryLayout<T> createStatic(HierarchyNode<T> node) {
-        HierarchyEntryLayout<T> newLayout = new HierarchyEntryLayout<T>(node);
-        return newLayout;
+        return new HierarchyEntryLayout<>(node);
     }
 
     public HierarchyEntryLayout<T> createRemovable(HierarchyNode<T> node) {
-        HierarchyEntryLayout<T> newLayout = new HierarchyEntryLayout<T>(node);
-        if (node.getChildren().size() == 0) {
+        HierarchyEntryLayout<T> newLayout = new HierarchyEntryLayout<>(node);
+        if (node.getChildren().isEmpty()) {
             Button newButton =
-                    new Button(
-                            new Icon(VaadinIcon.TRASH),
-                            click -> {
-                                newLayout.handleDelteEvent();
-                            });
+                    new Button(new Icon(VaadinIcon.TRASH), click -> newLayout.handleDeleteEvent());
             // TODO button should not ne only invisible when children are there but should be greyed
             // out
             // newButton.setEnabled(false);
@@ -34,19 +28,12 @@ public class HierarchyEntryLayoutFactory<T extends HierarchyObject> {
     }
 
     public HierarchyEntryLayout<T> createEditable(HierarchyNode<T> node) {
-        HierarchyEntryLayout<T> newLayout = new HierarchyEntryLayout<T>(node);
+        HierarchyEntryLayout<T> newLayout = new HierarchyEntryLayout<>(node);
         newLayout.add(
                 new Button(
-                        new Icon(VaadinIcon.EDIT),
-                        click -> {
-                            newLayout.handleEditorRequestEvent();
-                        }));
+                        new Icon(VaadinIcon.EDIT), click -> newLayout.handleEditorRequestEvent()));
         newLayout.add(
-                new Button(
-                        new Icon(VaadinIcon.TRASH),
-                        click -> {
-                            newLayout.handleDelteEvent();
-                        }));
+                new Button(new Icon(VaadinIcon.TRASH), click -> newLayout.handleDeleteEvent()));
         return newLayout;
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyView.java
@@ -28,6 +28,8 @@ import org.archcnl.ui.common.conceptandrelationlistview.events.HierarchySwapRequ
 import org.archcnl.ui.common.conceptandrelationlistview.events.NodeAddRequestedEvent;
 
 public class HierarchyView<T extends HierarchyObject> extends VerticalLayout {
+
+    private static final long serialVersionUID = 4353502586813149848L;
     private TreeGrid<HierarchyNode<T>> treeGrid;
     private List<HierarchyNode<T>> roots;
     private List<HierarchyNode<T>> expandedNodes;
@@ -44,9 +46,9 @@ public class HierarchyView<T extends HierarchyObject> extends VerticalLayout {
     public HierarchyView() {
         setClassName("hierarchy");
         footer = new HorizontalLayout();
-        roots = new ArrayList<HierarchyNode<T>>();
-        expandedNodes = new ArrayList<HierarchyNode<T>>(roots);
-        treeGrid = new TreeGrid<HierarchyNode<T>>();
+        roots = new ArrayList<>();
+        expandedNodes = new ArrayList<>(roots);
+        treeGrid = new TreeGrid<>();
         treeGrid.setDropMode(GridDropMode.ON_TOP_OR_BETWEEN);
         treeGrid.setRowsDraggable(true);
         treeGrid.addExpandListener(e -> expandedNodes.addAll(e.getItems()));
@@ -103,9 +105,9 @@ public class HierarchyView<T extends HierarchyObject> extends VerticalLayout {
         return footer;
     }
 
-    public HierarchyEntryLayout createNewHierarchyEntry(HierarchyNode node) {
+    public HierarchyEntryLayout<T> createNewHierarchyEntry(HierarchyNode<T> node) {
         HierarchyEntryLayout<T> newLayout;
-        HierarchyEntryLayoutFactory factory = new HierarchyEntryLayoutFactory<T>();
+        HierarchyEntryLayoutFactory<T> factory = new HierarchyEntryLayoutFactory<>();
         if (node.isRemoveable()) {
             newLayout = factory.createRemovable(node);
             newLayout.addListener(DeleteHierarchyObjectRequestedEvent.class, this::fireEvent);
@@ -126,16 +128,13 @@ public class HierarchyView<T extends HierarchyObject> extends VerticalLayout {
                         fireEvent(new NodeAddRequestedEvent(this, newTextField.getValue(), true));
                     }
                 });
-        newTextField.addBlurListener(
-                e -> {
-                    footer.replace(newTextField, addNode);
-                });
+        newTextField.addBlurListener(e -> footer.replace(newTextField, addNode));
 
         footer.replace(addNodeElement, newTextField);
     }
 
     public void addSection(String sectionName) {
-        roots.add(new HierarchyNode<T>(sectionName));
+        roots.add(new HierarchyNode<>(sectionName));
     }
 
     public void setRoots(List<HierarchyNode<T>> l) {
@@ -167,14 +166,9 @@ public class HierarchyView<T extends HierarchyObject> extends VerticalLayout {
     }
 
     @Override
-    public <T extends ComponentEvent<?>> Registration addListener(
-            final Class<T> eventType, final ComponentEventListener<T> listener) {
+    public <E extends ComponentEvent<?>> Registration addListener(
+            final Class<E> eventType, final ComponentEventListener<E> listener) {
         return getEventBus().addListener(eventType, listener);
-    }
-
-    private void getData() {
-        // Collection<Foo> sourceItems = ((TreeDataProvider<Foo>)
-        // fooTreeGrid.getDataProvider()).getTreeData().getRootItems();
     }
 
     private void setUpDragAndDrop() {
@@ -193,9 +187,10 @@ public class HierarchyView<T extends HierarchyObject> extends VerticalLayout {
 
                     if (dropLocation == GridDropLocation.ON_TOP) {
                         fireEvent(
-                                new HierarchySwapRequestedEvent(
+                                new HierarchySwapRequestedEvent<T>(
                                         this, false, draggedItem, targetNode, dropLocation));
                     } else {
+                        // TODO: Notify the user
                     }
                     requestGridUpdate();
                 });

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/HierarchyView.java
@@ -53,10 +53,7 @@ public class HierarchyView<T extends HierarchyObject> extends VerticalLayout {
         treeGrid.setRowsDraggable(true);
         treeGrid.addExpandListener(e -> expandedNodes.addAll(e.getItems()));
         treeGrid.addCollapseListener(e -> expandedNodes.removeAll(e.getItems()));
-        treeGrid.addComponentHierarchyColumn(
-                node -> {
-                    return createNewHierarchyEntry(node);
-                });
+        treeGrid.addComponentHierarchyColumn(this::createNewHierarchyEntry);
         setUpDragAndDrop();
         add(treeGrid);
         add(footer);
@@ -105,9 +102,9 @@ public class HierarchyView<T extends HierarchyObject> extends VerticalLayout {
         return footer;
     }
 
-    public HierarchyEntryLayout<T> createNewHierarchyEntry(HierarchyNode<T> node) {
+    public HierarchyEntryLayout createNewHierarchyEntry(HierarchyNode node) {
         HierarchyEntryLayout<T> newLayout;
-        HierarchyEntryLayoutFactory<T> factory = new HierarchyEntryLayoutFactory<>();
+        HierarchyEntryLayoutFactory factory = new HierarchyEntryLayoutFactory<>();
         if (node.isRemoveable()) {
             newLayout = factory.createRemovable(node);
             newLayout.addListener(DeleteHierarchyObjectRequestedEvent.class, this::fireEvent);
@@ -131,10 +128,6 @@ public class HierarchyView<T extends HierarchyObject> extends VerticalLayout {
         newTextField.addBlurListener(e -> footer.replace(newTextField, addNode));
 
         footer.replace(addNodeElement, newTextField);
-    }
-
-    public void addSection(String sectionName) {
-        roots.add(new HierarchyNode<>(sectionName));
     }
 
     public void setRoots(List<HierarchyNode<T>> l) {
@@ -187,7 +180,7 @@ public class HierarchyView<T extends HierarchyObject> extends VerticalLayout {
 
                     if (dropLocation == GridDropLocation.ON_TOP) {
                         fireEvent(
-                                new HierarchySwapRequestedEvent<T>(
+                                new HierarchySwapRequestedEvent(
                                         this, false, draggedItem, targetNode, dropLocation));
                     } else {
                         // TODO: Notify the user

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/ConceptHierarchySwapRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/ConceptHierarchySwapRequestedEvent.java
@@ -1,12 +1,10 @@
 package org.archcnl.ui.common.conceptandrelationlistview.events;
 
-import org.archcnl.domain.common.conceptsandrelations.Concept;
-
-public class ConceptHierarchySwapRequestedEvent extends HierarchySwapRequestedEvent<Concept> {
+public class ConceptHierarchySwapRequestedEvent extends HierarchySwapRequestedEvent {
 
     private static final long serialVersionUID = 1L;
 
-    public ConceptHierarchySwapRequestedEvent(HierarchySwapRequestedEvent<Concept> e) {
+    public ConceptHierarchySwapRequestedEvent(HierarchySwapRequestedEvent e) {
         super(e.getSource(), true, e.getDraggedNode(), e.getTargetNode(), e.getGridDropLocation());
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/ConceptHierarchySwapRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/ConceptHierarchySwapRequestedEvent.java
@@ -1,21 +1,12 @@
 package org.archcnl.ui.common.conceptandrelationlistview.events;
 
-import com.vaadin.flow.component.grid.dnd.GridDropLocation;
-import org.archcnl.domain.common.HierarchyNode;
-import org.archcnl.ui.common.conceptandrelationlistview.HierarchyView;
+import org.archcnl.domain.common.conceptsandrelations.Concept;
 
-public class ConceptHierarchySwapRequestedEvent extends HierarchySwapRequestedEvent {
+public class ConceptHierarchySwapRequestedEvent extends HierarchySwapRequestedEvent<Concept> {
 
-    public ConceptHierarchySwapRequestedEvent(
-            HierarchyView source,
-            boolean fromClient,
-            HierarchyNode draggedNode,
-            HierarchyNode targetNode,
-            GridDropLocation gridDropLocation) {
-        super(source, fromClient, draggedNode, targetNode, gridDropLocation);
-    }
+    private static final long serialVersionUID = 1L;
 
-    public ConceptHierarchySwapRequestedEvent(HierarchySwapRequestedEvent e) {
+    public ConceptHierarchySwapRequestedEvent(HierarchySwapRequestedEvent<Concept> e) {
         super(e.getSource(), true, e.getDraggedNode(), e.getTargetNode(), e.getGridDropLocation());
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/DeleteConceptRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/DeleteConceptRequestedEvent.java
@@ -8,15 +8,15 @@ import org.archcnl.ui.common.conceptandrelationlistview.HierarchyView;
 public class DeleteConceptRequestedEvent extends ComponentEvent<HierarchyView<Concept>> {
 
     private static final long serialVersionUID = 8376060245715843882L;
-    private HierarchyNode entry;
+    private HierarchyNode<Concept> entry;
 
     public DeleteConceptRequestedEvent(
-            HierarchyView<Concept> source, boolean fromClient, HierarchyNode concept) {
+            HierarchyView<Concept> source, boolean fromClient, HierarchyNode<Concept> concept) {
         super(source, fromClient);
         this.entry = concept;
     }
 
-    public HierarchyNode getConcept() {
+    public HierarchyNode<Concept> getHierarchyNode() {
         return entry;
     }
 

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/DeleteHierarchyObjectRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/DeleteHierarchyObjectRequestedEvent.java
@@ -3,21 +3,19 @@ package org.archcnl.ui.common.conceptandrelationlistview.events;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import org.archcnl.domain.common.HierarchyNode;
-import org.archcnl.domain.common.conceptsandrelations.HierarchyObject;
 
-public class DeleteHierarchyObjectRequestedEvent<T extends HierarchyObject>
-        extends ComponentEvent<Component> {
+public class DeleteHierarchyObjectRequestedEvent extends ComponentEvent<Component> {
 
     private static final long serialVersionUID = -8244752047463443057L;
-    private HierarchyNode<T> hierarchyNode;
+    private HierarchyNode hierarchyNode;
 
     public DeleteHierarchyObjectRequestedEvent(
-            Component component, boolean fromClient, HierarchyNode<T> hierarchyNode) {
+            Component component, boolean fromClient, HierarchyNode hierarchyNode) {
         super(component, fromClient);
         this.hierarchyNode = hierarchyNode;
     }
 
-    public HierarchyNode<T> getHierarchyNode() {
+    public HierarchyNode getHierarchyNode() {
         return hierarchyNode;
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/DeleteHierarchyObjectRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/DeleteHierarchyObjectRequestedEvent.java
@@ -3,19 +3,21 @@ package org.archcnl.ui.common.conceptandrelationlistview.events;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import org.archcnl.domain.common.HierarchyNode;
+import org.archcnl.domain.common.conceptsandrelations.HierarchyObject;
 
-public class DeleteHierarchyObjectRequestedEvent extends ComponentEvent<Component> {
+public class DeleteHierarchyObjectRequestedEvent<T extends HierarchyObject>
+        extends ComponentEvent<Component> {
 
     private static final long serialVersionUID = -8244752047463443057L;
-    private HierarchyNode hierarchyNode;
+    private HierarchyNode<T> hierarchyNode;
 
     public DeleteHierarchyObjectRequestedEvent(
-            Component component, boolean fromClient, HierarchyNode hierarchyNode) {
+            Component component, boolean fromClient, HierarchyNode<T> hierarchyNode) {
         super(component, fromClient);
         this.hierarchyNode = hierarchyNode;
     }
 
-    public HierarchyNode getHierarchyObject() {
+    public HierarchyNode<T> getHierarchyNode() {
         return hierarchyNode;
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/DeleteRelationRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/DeleteRelationRequestedEvent.java
@@ -8,15 +8,15 @@ import org.archcnl.ui.common.conceptandrelationlistview.HierarchyView;
 public class DeleteRelationRequestedEvent extends ComponentEvent<HierarchyView<Relation>> {
 
     private static final long serialVersionUID = 2597979523906513573L;
-    private HierarchyNode entry;
+    private HierarchyNode<Relation> entry;
 
     public DeleteRelationRequestedEvent(
-            HierarchyView<Relation> source, boolean fromClient, HierarchyNode relation) {
+            HierarchyView<Relation> source, boolean fromClient, HierarchyNode<Relation> relation) {
         super(source, fromClient);
         this.entry = relation;
     }
 
-    public HierarchyNode getRelation() {
+    public HierarchyNode<Relation> getHierarchyNode() {
         return entry;
     }
 

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/EditorRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/EditorRequestedEvent.java
@@ -1,11 +1,16 @@
 package org.archcnl.ui.common.conceptandrelationlistview.events;
 
 import com.vaadin.flow.component.ComponentEvent;
+import org.archcnl.domain.common.conceptsandrelations.HierarchyObject;
 import org.archcnl.ui.common.conceptandrelationlistview.HierarchyEntryLayout;
 
-public class EditorRequestedEvent extends ComponentEvent<HierarchyEntryLayout> {
+public class EditorRequestedEvent
+        extends ComponentEvent<HierarchyEntryLayout<? extends HierarchyObject>> {
 
-    public EditorRequestedEvent(HierarchyEntryLayout source, boolean isFromClient) {
+    private static final long serialVersionUID = 2452035282766848616L;
+
+    public EditorRequestedEvent(
+            HierarchyEntryLayout<? extends HierarchyObject> source, boolean isFromClient) {
         super(source, isFromClient);
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/GridUpdateRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/GridUpdateRequestedEvent.java
@@ -1,13 +1,16 @@
 package org.archcnl.ui.common.conceptandrelationlistview.events;
 
 import com.vaadin.flow.component.ComponentEvent;
+import org.archcnl.domain.common.conceptsandrelations.HierarchyObject;
 import org.archcnl.ui.common.conceptandrelationlistview.HierarchyView;
 
-public class GridUpdateRequestedEvent extends ComponentEvent<HierarchyView> {
+public class GridUpdateRequestedEvent
+        extends ComponentEvent<HierarchyView<? extends HierarchyObject>> {
 
     private static final long serialVersionUID = -3711307621533570697L;
 
-    public GridUpdateRequestedEvent(final HierarchyView source, final boolean fromClient) {
+    public GridUpdateRequestedEvent(
+            final HierarchyView<? extends HierarchyObject> source, final boolean fromClient) {
         super(source, fromClient);
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/HierarchySwapRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/HierarchySwapRequestedEvent.java
@@ -3,18 +3,22 @@ package org.archcnl.ui.common.conceptandrelationlistview.events;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.grid.dnd.GridDropLocation;
 import org.archcnl.domain.common.HierarchyNode;
+import org.archcnl.domain.common.conceptsandrelations.HierarchyObject;
 import org.archcnl.ui.common.conceptandrelationlistview.HierarchyView;
 
-public class HierarchySwapRequestedEvent extends ComponentEvent<HierarchyView> {
-    HierarchyNode dragged;
-    HierarchyNode target;
+public class HierarchySwapRequestedEvent<T extends HierarchyObject>
+        extends ComponentEvent<HierarchyView<T>> {
+
+    private static final long serialVersionUID = 407454874319949811L;
+    HierarchyNode<T> dragged;
+    HierarchyNode<T> target;
     GridDropLocation location;
 
     public HierarchySwapRequestedEvent(
-            HierarchyView source,
+            HierarchyView<T> source,
             boolean fromClient,
-            HierarchyNode draggedNode,
-            HierarchyNode targetNode,
+            HierarchyNode<T> draggedNode,
+            HierarchyNode<T> targetNode,
             GridDropLocation gridDropLocation) {
         super(source, fromClient);
         dragged = draggedNode;
@@ -22,11 +26,11 @@ public class HierarchySwapRequestedEvent extends ComponentEvent<HierarchyView> {
         location = gridDropLocation;
     }
 
-    public HierarchyNode getDraggedNode() {
+    public HierarchyNode<T> getDraggedNode() {
         return dragged;
     }
 
-    public HierarchyNode getTargetNode() {
+    public HierarchyNode<T> getTargetNode() {
         return target;
     }
 

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/HierarchySwapRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/HierarchySwapRequestedEvent.java
@@ -3,22 +3,20 @@ package org.archcnl.ui.common.conceptandrelationlistview.events;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.grid.dnd.GridDropLocation;
 import org.archcnl.domain.common.HierarchyNode;
-import org.archcnl.domain.common.conceptsandrelations.HierarchyObject;
 import org.archcnl.ui.common.conceptandrelationlistview.HierarchyView;
 
-public class HierarchySwapRequestedEvent<T extends HierarchyObject>
-        extends ComponentEvent<HierarchyView<T>> {
+public class HierarchySwapRequestedEvent extends ComponentEvent<HierarchyView> {
 
     private static final long serialVersionUID = 407454874319949811L;
-    HierarchyNode<T> dragged;
-    HierarchyNode<T> target;
+    HierarchyNode dragged;
+    HierarchyNode target;
     GridDropLocation location;
 
     public HierarchySwapRequestedEvent(
-            HierarchyView<T> source,
+            HierarchyView source,
             boolean fromClient,
-            HierarchyNode<T> draggedNode,
-            HierarchyNode<T> targetNode,
+            HierarchyNode draggedNode,
+            HierarchyNode targetNode,
             GridDropLocation gridDropLocation) {
         super(source, fromClient);
         dragged = draggedNode;
@@ -26,11 +24,11 @@ public class HierarchySwapRequestedEvent<T extends HierarchyObject>
         location = gridDropLocation;
     }
 
-    public HierarchyNode<T> getDraggedNode() {
+    public HierarchyNode getDraggedNode() {
         return dragged;
     }
 
-    public HierarchyNode<T> getTargetNode() {
+    public HierarchyNode getTargetNode() {
         return target;
     }
 

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/NodeAddRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/NodeAddRequestedEvent.java
@@ -1,19 +1,27 @@
 package org.archcnl.ui.common.conceptandrelationlistview.events;
 
 import com.vaadin.flow.component.ComponentEvent;
+import org.archcnl.domain.common.conceptsandrelations.HierarchyObject;
 import org.archcnl.ui.common.conceptandrelationlistview.HierarchyView;
 
-public class NodeAddRequestedEvent extends ComponentEvent<HierarchyView> {
+public class NodeAddRequestedEvent
+        extends ComponentEvent<HierarchyView<? extends HierarchyObject>> {
+
+    private static final long serialVersionUID = -6392097240611643823L;
+
     public enum NodeType {
         CONCEPT,
         RELATION,
         UNKNOWN
-    };
+    }
 
     private String nodename;
     private NodeType nodeType;
 
-    public NodeAddRequestedEvent(HierarchyView source, String nodename, boolean isFromClient) {
+    public NodeAddRequestedEvent(
+            HierarchyView<? extends HierarchyObject> source,
+            String nodename,
+            boolean isFromClient) {
         super(source, isFromClient);
         this.nodename = nodename;
         this.nodeType = NodeType.UNKNOWN;

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/RelationHierarchySwapRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/RelationHierarchySwapRequestedEvent.java
@@ -1,21 +1,12 @@
 package org.archcnl.ui.common.conceptandrelationlistview.events;
 
-import com.vaadin.flow.component.grid.dnd.GridDropLocation;
-import org.archcnl.domain.common.HierarchyNode;
-import org.archcnl.ui.common.conceptandrelationlistview.HierarchyView;
+import org.archcnl.domain.common.conceptsandrelations.Relation;
 
-public class RelationHierarchySwapRequestedEvent extends HierarchySwapRequestedEvent {
+public class RelationHierarchySwapRequestedEvent extends HierarchySwapRequestedEvent<Relation> {
 
-    public RelationHierarchySwapRequestedEvent(
-            HierarchyView source,
-            boolean fromClient,
-            HierarchyNode draggedNode,
-            HierarchyNode targetNode,
-            GridDropLocation gridDropLocation) {
-        super(source, fromClient, draggedNode, targetNode, gridDropLocation);
-    }
+    private static final long serialVersionUID = -7059656468211729847L;
 
-    public RelationHierarchySwapRequestedEvent(HierarchySwapRequestedEvent e) {
+    public RelationHierarchySwapRequestedEvent(HierarchySwapRequestedEvent<Relation> e) {
         super(e.getSource(), true, e.getDraggedNode(), e.getTargetNode(), e.getGridDropLocation());
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/RelationHierarchySwapRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/common/conceptandrelationlistview/events/RelationHierarchySwapRequestedEvent.java
@@ -1,12 +1,10 @@
 package org.archcnl.ui.common.conceptandrelationlistview.events;
 
-import org.archcnl.domain.common.conceptsandrelations.Relation;
-
-public class RelationHierarchySwapRequestedEvent extends HierarchySwapRequestedEvent<Relation> {
+public class RelationHierarchySwapRequestedEvent extends HierarchySwapRequestedEvent {
 
     private static final long serialVersionUID = -7059656468211729847L;
 
-    public RelationHierarchySwapRequestedEvent(HierarchySwapRequestedEvent<Relation> e) {
+    public RelationHierarchySwapRequestedEvent(HierarchySwapRequestedEvent e) {
         super(e.getSource(), true, e.getDraggedNode(), e.getTargetNode(), e.getGridDropLocation());
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/presets/PresetsDialogPresenter.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/presets/PresetsDialogPresenter.java
@@ -16,8 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.archcnl.domain.common.ConceptManager;
 import org.archcnl.domain.common.RelationManager;
 import org.archcnl.domain.input.model.architecturerules.ArchitectureRuleManager;
@@ -46,12 +44,10 @@ public class PresetsDialogPresenter extends Dialog {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger LOG = LogManager.getLogger(PresetsDialogPresenter.class);
-
     private final PresetsDialogView view;
 
     private Tabs tabs = new Tabs();
-    private Map<Tab, Component> tabsToComponent = new LinkedHashMap<Tab, Component>();
+    private Map<Tab, Component> tabsToComponent = new LinkedHashMap<>();
     private Tab styleSelectionTab;
     private Tab ruleSelectionTab;
     private Tab architectureInformationTab;

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/presets/PresetsDialogView.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/presets/PresetsDialogView.java
@@ -15,8 +15,6 @@ import com.vaadin.flow.component.tabs.Tabs;
 import com.vaadin.flow.shared.Registration;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.archcnl.ui.inputview.presets.PresetsDialogPresenter.TabOptions;
 import org.archcnl.ui.inputview.presets.events.ArchitectureRulesSelectedEvent;
 import org.archcnl.ui.inputview.presets.events.RuleSelectionTabRequestedEvent;
@@ -25,8 +23,6 @@ import org.archcnl.ui.inputview.presets.events.ValidateArchitecturalStyleFormEve
 public class PresetsDialogView extends Dialog implements HasComponents, FlexComponent<Component> {
 
     private static final long serialVersionUID = 1L;
-
-    private static final Logger LOG = LogManager.getLogger(PresetsDialogView.class);
 
     private Tabs tabs = new Tabs();
     private Map<Tab, Component> tabsToComponent;
@@ -60,23 +56,17 @@ public class PresetsDialogView extends Dialog implements HasComponents, FlexComp
         switch (tab) {
             case STYLE_SELECTION:
                 confirm.addClickListener(
-                        e -> {
-                            fireEvent(new RuleSelectionTabRequestedEvent(this, false));
-                        });
+                        e -> fireEvent(new RuleSelectionTabRequestedEvent(this, false)));
                 break;
             case RULE_SELECTION:
                 confirm.addClickListener(
-                        e -> {
-                            fireEvent(new ArchitectureRulesSelectedEvent(this, false));
-                        });
+                        e -> fireEvent(new ArchitectureRulesSelectedEvent(this, false)));
                 break;
             case ARCHITECTURE_INFORMATION:
                 confirm = new Button("Create Rules & Mappings");
 
                 confirm.addClickListener(
-                        e -> {
-                            fireEvent(new ValidateArchitecturalStyleFormEvent(this, false));
-                        });
+                        e -> fireEvent(new ValidateArchitecturalStyleFormEvent(this, false)));
                 break;
             default:
                 break;

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/presets/events/ValidateArchitecturalStyleFormEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/presets/events/ValidateArchitecturalStyleFormEvent.java
@@ -1,18 +1,11 @@
 package org.archcnl.ui.inputview.presets.events;
 
 import com.vaadin.flow.component.ComponentEvent;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.archcnl.domain.input.model.presets.ArchitecturalStyle;
 import org.archcnl.ui.inputview.presets.PresetsDialogView;
 
 public class ValidateArchitecturalStyleFormEvent extends ComponentEvent<PresetsDialogView> {
 
-    private static final Logger LOG =
-            LogManager.getLogger(ValidateArchitecturalStyleFormEvent.class);
     private static final long serialVersionUID = 1L;
-
-    private ArchitecturalStyle style;
 
     public ValidateArchitecturalStyleFormEvent(PresetsDialogView source, boolean fromClient) {
         super(source, fromClient);

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/concepteditor/events/AddCustomConceptRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/concepteditor/events/AddCustomConceptRequestedEvent.java
@@ -18,7 +18,7 @@ public class AddCustomConceptRequestedEvent extends ComponentEvent<ConceptEditor
     }
 
     public void handleEvent(ConceptManager conceptManager) {
-        if (!conceptManager.doesConceptExist(concept)) {
+        if (!conceptManager.doesConceptExist(concept.getName())) {
             try {
                 conceptManager.addToParent(concept, "Custom Concepts");
             } catch (ConceptAlreadyExistsException e) {

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/concepteditor/events/ChangeConceptNameRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/concepteditor/events/ChangeConceptNameRequestedEvent.java
@@ -24,11 +24,9 @@ public class ChangeConceptNameRequestedEvent extends ComponentEvent<ConceptEdito
 
     public void handleEvent(ConceptManager conceptManager) {
         try {
-            concept.changeName(newName, conceptManager);
+            conceptManager.updateName(concept.getName(), newName);
         } catch (final ConceptAlreadyExistsException e) {
-            if (!newName.equals(concept.getName())) {
-                getSource().showNameAlreadyTakenErrorMessage();
-            }
+            getSource().showNameAlreadyTakenErrorMessage();
         }
     }
 }

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/relationeditor/events/AddCustomRelationRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/relationeditor/events/AddCustomRelationRequestedEvent.java
@@ -31,7 +31,7 @@ public class AddCustomRelationRequestedEvent extends ComponentEvent<RelationEdit
         } catch (UnrelatedMappingException e) {
             throw new RuntimeException(e.getMessage());
         }
-        if (!relationManager.doesRelationExist(relation)) {
+        if (!relationManager.doesRelationExist(relation.getName())) {
             try {
                 relationManager.addToParent(relation, "Custom Relations");
             } catch (RelationAlreadyExistsException e) {

--- a/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/relationeditor/events/ChangeRelationNameRequestedEvent.java
+++ b/web-ui/src/main/java/org/archcnl/ui/inputview/rulesormappingeditorview/mappingeditor/relationeditor/events/ChangeRelationNameRequestedEvent.java
@@ -24,11 +24,9 @@ public class ChangeRelationNameRequestedEvent extends ComponentEvent<RelationEdi
 
     public void handleEvent(RelationManager relationManager) {
         try {
-            relation.changeName(newName, relationManager);
+            relationManager.updateName(relation.getName(), newName);
         } catch (final RelationAlreadyExistsException e) {
-            if (!newName.equals(relation.getName())) {
-                getSource().showNameAlreadyTakenErrorMessage();
-            }
+            getSource().showNameAlreadyTakenErrorMessage();
         }
     }
 }

--- a/web-ui/src/test/java/org/archcnl/domain/common/ConceptManagerTest.java
+++ b/web-ui/src/test/java/org/archcnl/domain/common/ConceptManagerTest.java
@@ -59,43 +59,30 @@ class ConceptManagerTest {
             throws ConceptDoesNotExistException {
         Assertions.assertEquals(inputConceptsCount, conceptManager.getInputConcepts().size());
         Assertions.assertEquals(outputConceptsCount, conceptManager.getOutputConcepts().size());
-        Assertions.assertFalse(conceptManager.doesConceptExist(new FamixConcept("ABC", "")));
+        Assertions.assertFalse(conceptManager.doesConceptExist("ABC"));
 
         // Famix
-        Assertions.assertTrue(conceptManager.doesConceptExist(new FamixConcept("FamixClass", "")));
-        Assertions.assertTrue(conceptManager.doesConceptExist(new FamixConcept("Namespace", "")));
-        Assertions.assertTrue(conceptManager.doesConceptExist(new FamixConcept("Enum", "")));
-        Assertions.assertTrue(
-                conceptManager.doesConceptExist(new FamixConcept("AnnotationType", "")));
-        Assertions.assertTrue(conceptManager.doesConceptExist(new FamixConcept("Method", "")));
-        Assertions.assertTrue(conceptManager.doesConceptExist(new FamixConcept("Attribute", "")));
-        Assertions.assertTrue(conceptManager.doesConceptExist(new FamixConcept("Inheritance", "")));
-        Assertions.assertTrue(
-                conceptManager.doesConceptExist(new FamixConcept("AnnotationInstance", "")));
-        Assertions.assertTrue(
-                conceptManager.doesConceptExist(new FamixConcept("AnnotationTypeAttribute", "")));
-        Assertions.assertTrue(
-                conceptManager.doesConceptExist(
-                        new FamixConcept("AnnotationInstanceAttribute", "")));
-        Assertions.assertTrue(conceptManager.doesConceptExist(new FamixConcept("Parameter", "")));
-        Assertions.assertTrue(
-                conceptManager.doesConceptExist(new FamixConcept("LocalVariable", "")));
-        Assertions.assertTrue(conceptManager.doesConceptExist(new FamixConcept("Exception", "")));
+        Assertions.assertTrue(conceptManager.doesConceptExist("FamixClass"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("Namespace"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("Enum"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("AnnotationType"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("Method"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("Attribute"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("Inheritance"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("AnnotationInstance"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("AnnotationTypeAttribute"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("AnnotationInstanceAttribute"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("Parameter"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("LocalVariable"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("Exception"));
 
         // Conformance
-        Assertions.assertTrue(
-                conceptManager.doesConceptExist(new ConformanceConcept("ConformanceCheck", "")));
-        Assertions.assertTrue(
-                conceptManager.doesConceptExist(new ConformanceConcept("ArchitectureRule", "")));
-        Assertions.assertTrue(
-                conceptManager.doesConceptExist(
-                        new ConformanceConcept("ArchitectureViolation", "")));
-        Assertions.assertTrue(conceptManager.doesConceptExist(new ConformanceConcept("Proof", "")));
-        Assertions.assertTrue(
-                conceptManager.doesConceptExist(new ConformanceConcept("AssertedStatement", "")));
-        Assertions.assertTrue(
-                conceptManager.doesConceptExist(
-                        new ConformanceConcept("NotInferredStatement", "")));
+        Assertions.assertTrue(conceptManager.doesConceptExist("ConformanceCheck"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("ArchitectureRule"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("ArchitectureViolation"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("Proof"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("AssertedStatement"));
+        Assertions.assertTrue(conceptManager.doesConceptExist("NotInferredStatement"));
     }
 
     @Test

--- a/web-ui/src/test/java/org/archcnl/domain/common/RelationManagerTest.java
+++ b/web-ui/src/test/java/org/archcnl/domain/common/RelationManagerTest.java
@@ -62,244 +62,54 @@ class RelationManagerTest {
     void givenRelationManager_whenCreated_thenExpectedRelations() {
         Assertions.assertEquals(inputRelationsCount, relationManager.getInputRelations().size());
         Assertions.assertEquals(outputRelationsCount, relationManager.getOutputRelations().size());
-        Assertions.assertFalse(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "abc", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
+        Assertions.assertFalse(relationManager.doesRelationExist("abc"));
 
         // Jena builtin
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new JenaBuiltinRelation(
-                                "matches",
-                                "regex",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
+        Assertions.assertTrue(relationManager.doesRelationExist("matches"));
 
         // Famix
-        Assertions.assertTrue(relationManager.doesRelationExist(TypeRelation.getTyperelation()));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasModifier", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasName", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "isLocatedAt", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasSignature", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasValue", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasFullQualifiedName",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "isConstructor",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "isExternal", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "isInterface", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasDefiningClass",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasDeclaredException",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasCaughtException",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "throwsException",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasSubClass", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasSuperClass",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "definesNestedType",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "definesParameter",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "definesVariable",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasAnnotationInstance",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasAnnotationType",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasAnnotationTypeAttribute",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasAnnotationInstanceAttribute",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "definesAttribute",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "definesMethod",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "imports", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "namespaceContains",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new FamixRelation(
-                                "hasDeclaredType",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
+        Assertions.assertTrue(relationManager.doesRelationExist("is-of-type"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasModifier"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasName"));
+        Assertions.assertTrue(relationManager.doesRelationExist("isLocatedAt"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasSignature"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasValue"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasFullQualifiedName"));
+        Assertions.assertTrue(relationManager.doesRelationExist("isConstructor"));
+        Assertions.assertTrue(relationManager.doesRelationExist("isExternal"));
+        Assertions.assertTrue(relationManager.doesRelationExist("isInterface"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasDefiningClass"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasDeclaredException"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasCaughtException"));
+        Assertions.assertTrue(relationManager.doesRelationExist("throwsException"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasSubClass"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasSuperClass"));
+        Assertions.assertTrue(relationManager.doesRelationExist("definesNestedType"));
+        Assertions.assertTrue(relationManager.doesRelationExist("definesParameter"));
+        Assertions.assertTrue(relationManager.doesRelationExist("definesVariable"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasAnnotationInstance"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasAnnotationType"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasAnnotationTypeAttribute"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasAnnotationInstanceAttribute"));
+        Assertions.assertTrue(relationManager.doesRelationExist("definesAttribute"));
+        Assertions.assertTrue(relationManager.doesRelationExist("definesMethod"));
+        Assertions.assertTrue(relationManager.doesRelationExist("imports"));
+        Assertions.assertTrue(relationManager.doesRelationExist("namespaceContains"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasDeclaredType"));
 
         // Conformance
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "hasRuleRepresentation",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "hasRuleType", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "hasNotInferredStatement",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "hasAssertedStatement",
-                                "",
-                                new LinkedHashSet<>(),
-                                new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "hasSubject", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "hasPredicate", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "hasObject", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "proofs", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "hasDetected", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "hasViolation", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "violates", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
-        Assertions.assertTrue(
-                relationManager.doesRelationExist(
-                        new ConformanceRelation(
-                                "validates", "", new LinkedHashSet<>(), new LinkedHashSet<>())));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasRuleRepresentation"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasRuleType"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasNotInferredStatement"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasAssertedStatement"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasSubject"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasPredicate"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasObject"));
+        Assertions.assertTrue(relationManager.doesRelationExist("proofs"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasDetected"));
+        Assertions.assertTrue(relationManager.doesRelationExist("hasViolation"));
+        Assertions.assertTrue(relationManager.doesRelationExist("violates"));
+        Assertions.assertTrue(relationManager.doesRelationExist("validates"));
     }
 
     @Test

--- a/web-ui/src/test/java/org/archcnl/domain/input/model/mappings/RelationMappingTest.java
+++ b/web-ui/src/test/java/org/archcnl/domain/input/model/mappings/RelationMappingTest.java
@@ -1,9 +1,11 @@
 package org.archcnl.domain.input.model.mappings;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.LinkedList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.archcnl.domain.TestUtils;
 import org.archcnl.domain.common.conceptsandrelations.CustomRelation;
 import org.archcnl.domain.common.conceptsandrelations.andtriplets.triplet.exceptions.UnsupportedObjectTypeException;
@@ -24,9 +26,12 @@ class RelationMappingTest {
         List<CustomRelation> customRelations = TestUtils.prepareCustomRelations();
 
         // when
-        List<RelationMapping> actual = new LinkedList<>();
-        customRelations.forEach(
-                relation -> relation.getMapping().ifPresent(mapping -> actual.add(mapping)));
+        Map<String, RelationMapping> actual = new HashMap<>();
+        for (CustomRelation relation : customRelations) {
+            if (relation.getMapping().isPresent()) {
+                actual.put(relation.getName(), relation.getMapping().get());
+            }
+        }
 
         String expectedResideIn =
                 "resideInMapping: (?class rdf:type famix:FamixClass)"
@@ -53,16 +58,22 @@ class RelationMappingTest {
 
         // then
         assertEquals(5, actual.size());
-        assertEquals(1, actual.get(0).transformToAdoc().size());
-        assertEquals(expectedResideIn, actual.get(0).transformToAdoc().get(0));
-        assertEquals(2, actual.get(1).transformToAdoc().size());
-        assertEquals(expectedUse1, actual.get(1).transformToAdoc().get(0));
-        assertEquals(expectedUse2, actual.get(1).transformToAdoc().get(1));
-        assertEquals(1, actual.get(2).transformToAdoc().size());
-        assertEquals(expectedEmptyVariableMapping, actual.get(2).transformToAdoc().get(0));
-        assertEquals(1, actual.get(3).transformToAdoc().size());
-        assertEquals(expectedEmptyStringMapping, actual.get(3).transformToAdoc().get(0));
-        assertEquals(1, actual.get(4).transformToAdoc().size());
-        assertEquals(expectedEmptyBooleanMapping, actual.get(4).transformToAdoc().get(0));
+        assertEquals(1, actual.get("resideIn").transformToAdoc().size());
+        assertEquals(expectedResideIn, actual.get("resideIn").transformToAdoc().get(0));
+        assertEquals(2, actual.get("use").transformToAdoc().size());
+        assertTrue(actual.get("use").transformToAdoc().contains(expectedUse1));
+        assertTrue(actual.get("use").transformToAdoc().contains(expectedUse2));
+        assertEquals(1, actual.get("emptyWhenRelationVariable").transformToAdoc().size());
+        assertEquals(
+                expectedEmptyVariableMapping,
+                actual.get("emptyWhenRelationVariable").transformToAdoc().get(0));
+        assertEquals(1, actual.get("emptyWhenRelationString").transformToAdoc().size());
+        assertEquals(
+                expectedEmptyStringMapping,
+                actual.get("emptyWhenRelationString").transformToAdoc().get(0));
+        assertEquals(1, actual.get("emptyWhenRelationBoolean").transformToAdoc().size());
+        assertEquals(
+                expectedEmptyBooleanMapping,
+                actual.get("emptyWhenRelationBoolean").transformToAdoc().get(0));
     }
 }

--- a/web-ui/src/test/resources/EndToEndTest.adoc
+++ b/web-ui/src/test/resources/EndToEndTest.adoc
@@ -4,6 +4,12 @@ Every Aggregate must resideIn a DomainRing.
 [role="rule"]
 No Aggregate can use an ApplicationService.
 
+[role="mapping"]
+isEmptyWhenConcept: -> (?var rdf:type architecture:EmptyWhenConcept)
+
+[role="mapping"]
+isDomainRing: (?package rdf:type famix:Namespace) (?package famix:hasName ?name) regex(?name, 'domain') -> (?package rdf:type architecture:DomainRing)
+
 [role="description"]
 isAggregate: Every class whose name ends with Aggregate is an Aggregate.
 [role="mapping"]
@@ -11,12 +17,6 @@ isAggregate: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) reg
 
 [role="mapping"]
 isApplicationService: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:hasName ?name) regex(?name, 'api') (?package famix:namespaceContains ?class) -> (?class rdf:type architecture:ApplicationService)
-
-[role="mapping"]
-isDomainRing: (?package rdf:type famix:Namespace) (?package famix:hasName ?name) regex(?name, 'domain') -> (?package rdf:type architecture:DomainRing)
-
-[role="mapping"]
-isEmptyWhenConcept: -> (?var rdf:type architecture:EmptyWhenConcept)
 
 [role="mapping"]
 resideInMapping: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:namespaceContains ?class) -> (?class architecture:resideIn ?package)
@@ -33,10 +33,10 @@ useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClas
 emptyWhenRelationStringMapping: -> (?var architecture:emptyWhenRelationString 'test string')
 
 [role="mapping"]
-emptyWhenRelationBooleanMapping: -> (?var architecture:emptyWhenRelationBoolean 'false'^^xsd:boolean)
+emptyWhenRelationVariableMapping: -> (?var architecture:emptyWhenRelationVariable ?test)
 
 [role="mapping"]
-emptyWhenRelationVariableMapping: -> (?var architecture:emptyWhenRelationVariable ?test)
+emptyWhenRelationBooleanMapping: -> (?var architecture:emptyWhenRelationBoolean 'false'^^xsd:boolean)
 
 [role="customQuery"]
 classes: (SELECT ?class ?name)(WHERE (?class rdf:type famix:FamixClass)(?class famix:hasName ?name))

--- a/web-ui/src/test/resources/WriterTest.adoc
+++ b/web-ui/src/test/resources/WriterTest.adoc
@@ -4,6 +4,12 @@ Every Aggregate must resideIn a DomainRing.
 [role="rule"]
 No Aggregate can use an ApplicationService.
 
+[role="mapping"]
+isEmptyWhenConcept: -> (?var rdf:type architecture:EmptyWhenConcept)
+
+[role="mapping"]
+isDomainRing: (?package rdf:type famix:Namespace) (?package famix:hasName ?name) regex(?name, 'domain') -> (?package rdf:type architecture:DomainRing)
+
 [role="description"]
 isAggregate: Every class whose name ends with Aggregate is an Aggregate.
 [role="mapping"]
@@ -11,12 +17,6 @@ isAggregate: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) reg
 
 [role="mapping"]
 isApplicationService: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:hasName ?name) regex(?name, 'api') (?package famix:namespaceContains ?class) -> (?class rdf:type architecture:ApplicationService)
-
-[role="mapping"]
-isDomainRing: (?package rdf:type famix:Namespace) (?package famix:hasName ?name) regex(?name, 'domain') -> (?package rdf:type architecture:DomainRing)
-
-[role="mapping"]
-isEmptyWhenConcept: -> (?var rdf:type architecture:EmptyWhenConcept)
 
 [role="mapping"]
 resideInMapping: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:namespaceContains ?class) -> (?class architecture:resideIn ?package)
@@ -30,10 +30,10 @@ useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClas
 useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClass) (?class famix:imports ?class2) -> (?class architecture:use ?class2)
 
 [role="mapping"]
-emptyWhenRelationVariableMapping: -> (?var architecture:emptyWhenRelationVariable ?test)
+emptyWhenRelationStringMapping: -> (?var architecture:emptyWhenRelationString 'test string')
 
 [role="mapping"]
-emptyWhenRelationStringMapping: -> (?var architecture:emptyWhenRelationString 'test string')
+emptyWhenRelationVariableMapping: -> (?var architecture:emptyWhenRelationVariable ?test)
 
 [role="mapping"]
 emptyWhenRelationBooleanMapping: -> (?var architecture:emptyWhenRelationBoolean 'false'^^xsd:boolean)

--- a/web-ui/src/test/resources/architecture-documentation.adoc
+++ b/web-ui/src/test/resources/architecture-documentation.adoc
@@ -4,6 +4,12 @@ Every Aggregate must resideIn a DomainRing.
 [role="rule"]
 No Aggregate can use an ApplicationService.
 
+[role="mapping"]
+isEmptyWhenConcept: -> (?var rdf:type architecture:EmptyWhenConcept)
+
+[role="mapping"]
+isDomainRing: (?package rdf:type famix:Namespace) (?package famix:hasName ?name) regex(?name, 'domain') -> (?package rdf:type architecture:DomainRing)
+
 [role="description"]
 isAggregate: Every class whose name ends with Aggregate is an Aggregate.
 [role="mapping"]
@@ -11,12 +17,6 @@ isAggregate: (?class rdf:type famix:FamixClass) (?class famix:hasName ?name) reg
 
 [role="mapping"]
 isApplicationService: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:hasName ?name) regex(?name, 'api') (?package famix:namespaceContains ?class) -> (?class rdf:type architecture:ApplicationService)
-
-[role="mapping"]
-isDomainRing: (?package rdf:type famix:Namespace) (?package famix:hasName ?name) regex(?name, 'domain') -> (?package rdf:type architecture:DomainRing)
-
-[role="mapping"]
-isEmptyWhenConcept: -> (?var rdf:type architecture:EmptyWhenConcept)
 
 [role="mapping"]
 resideInMapping: (?class rdf:type famix:FamixClass) (?package rdf:type famix:Namespace) (?package famix:namespaceContains ?class) -> (?class architecture:resideIn ?package)
@@ -33,10 +33,10 @@ useMapping: (?class rdf:type famix:FamixClass) (?class2 rdf:type famix:FamixClas
 emptyWhenRelationStringMapping: -> (?var architecture:emptyWhenRelationString 'test string')
 
 [role="mapping"]
-emptyWhenRelationBooleanMapping: -> (?var architecture:emptyWhenRelationBoolean 'false'^^xsd:boolean)
+emptyWhenRelationVariableMapping: -> (?var architecture:emptyWhenRelationVariable ?test)
 
 [role="mapping"]
-emptyWhenRelationVariableMapping: -> (?var architecture:emptyWhenRelationVariable ?test)
+emptyWhenRelationBooleanMapping: -> (?var architecture:emptyWhenRelationBoolean 'false'^^xsd:boolean)
 
 [role="customQuery"]
 classes: (SELECT ?class ?name)(WHERE (?class rdf:type famix:FamixClass)(?class famix:hasName ?name))


### PR DESCRIPTION
- Fixed some warnings caused by the hierarchy feature in the GUI (more cleanup needed)
- Added missing short primitive to ontology and removed unsupported hasDefiningClass object property from FamixOntology
- Switched RelationManager list to map just like in ConceptManager
- Fixed missing update to key in the map of ConceptManager after renaming of Concept
- Removed unused code and simplified syntax in several places